### PR TITLE
Moving init_node call

### DIFF
--- a/qsr_lib/scripts/example_ros_client.py
+++ b/qsr_lib/scripts/example_ros_client.py
@@ -11,6 +11,7 @@
 """
 
 from __future__ import print_function, division
+import rospy
 import sys
 try:
     import cPickle as pickle
@@ -38,6 +39,8 @@ if __name__ == "__main__":
     parser.add_argument("--no_collapse", help="does not collapse similar adjacent states. Only QTC", action="store_true")
     parser.add_argument("--distance_threshold", help="distance threshold for qtcb <-> qtcc transition. Only QTCBC", type=float)
     args = parser.parse_args()
+
+    client_node = rospy.init_node("qsr_lib_ros_client_example")
 
     try:
         which_qsr_argv = args.qsr

--- a/qsr_lib/src/qsrlib_ros/qsrlib_ros_client.py
+++ b/qsr_lib/src/qsrlib_ros/qsrlib_ros_client.py
@@ -21,7 +21,6 @@ from qsr_lib.srv import *
 
 class QSRlib_ROS_Client(object):
     def __init__(self, service_node_name="qsr_lib"):
-        self.client_node = rospy.init_node("qsr_lib_ros_client_example")  # needed for rospy.get_rostime() in the request method
         self.service_topic_names = {"request": service_node_name+"/request"}
         print("Waiting for service '" + self.service_topic_names["request"] + "' to come up", end="")
         rospy.wait_for_service(self.service_topic_names["request"])


### PR DESCRIPTION
Closes #11

Moving the call to `rospy.init_node` out of the qsr ros client class.