### PR TITLE
Using rospy.log* for ROS node outputs.

### DIFF
--- a/qsr_lib/scripts/qsrlib_ros_server.py
+++ b/qsr_lib/scripts/qsrlib_ros_server.py
@@ -27,10 +27,10 @@ class QSRlib_ROS_Server(object):
         self.node = rospy.init_node(self.node_name)
         self.service_topic_names = {"request": self.node_name+"/request"}
         self.srv_qsrs_request = rospy.Service(self.service_topic_names["request"], RequestQSRs, self.handle_request_qsrs)
-        print("QSRlib_ROS_Server up and running, listening to:", self.service_topic_names["request"])
+        rospy.loginfo("QSRlib_ROS_Server up and running, listening to: %s" % self.service_topic_names["request"])
 
     def handle_request_qsrs(self, req):
-        print("Handling QSRs request made at", str(req.header.stamp.secs)+"."+str(req.header.stamp.nsecs))
+        rospy.logdebug("Handling QSRs request made at %i.%i" % (req.header.stamp.secs, req.header.stamp.nsecs))
         request_message = pickle.loads(req.data)
         qsrs_response_message = self.qsrlib.request_qsrs(request_message=request_message)
         res = RequestQSRsResponse()

--- a/qsr_lib/src/qsrlib_ros/qsrlib_ros_client.py
+++ b/qsr_lib/src/qsrlib_ros/qsrlib_ros_client.py
@@ -22,18 +22,18 @@ from qsr_lib.srv import *
 class QSRlib_ROS_Client(object):
     def __init__(self, service_node_name="qsr_lib"):
         self.service_topic_names = {"request": service_node_name+"/request"}
-        print("Waiting for service '" + self.service_topic_names["request"] + "' to come up", end="")
+        rospy.logdebug("Waiting for service '" + self.service_topic_names["request"] + "' to come up", end="")
         rospy.wait_for_service(self.service_topic_names["request"])
-        print("\tdone")
+        rospy.logdebug("done")
 
     def request_qsrs(self, req):
-        print("Requesting QSRs...")
+        rospy.logdebug("Requesting QSRs...")
         try:
             proxy = rospy.ServiceProxy(self.service_topic_names["request"], RequestQSRs)
             res = proxy(req)
             return res
         except rospy.ServiceException, e:
-            print("Service call failed: %s"%e)
+            rospy.logwarn("Service call failed: %s"%e)
 
     def make_ros_request_message(self, qsrlib_request_message):
             # following line gives the following error if there is no rospy.init_node(),

--- a/qsr_lib/src/qsrlib_ros/qsrlib_ros_client.py
+++ b/qsr_lib/src/qsrlib_ros/qsrlib_ros_client.py
@@ -22,7 +22,7 @@ from qsr_lib.srv import *
 class QSRlib_ROS_Client(object):
     def __init__(self, service_node_name="qsr_lib"):
         self.service_topic_names = {"request": service_node_name+"/request"}
-        rospy.logdebug("Waiting for service '" + self.service_topic_names["request"] + "' to come up", end="")
+        rospy.logdebug("Waiting for service '" + self.service_topic_names["request"] + "' to come up")
         rospy.wait_for_service(self.service_topic_names["request"])
         rospy.logdebug("done")
 


### PR DESCRIPTION
Prevents spamming the terminal by setting most of it to debug level. The current output just floods the terminal with unnecessary information.

The only issue with that is, that the line "Resetting QSRlib data" is a print from a not ROS dependent part of the lib. On the other hand, I don't even know what this is supposed to tell me. @yianni, can we delete this output or have a form of verbosity control? Currently the whole lib is way too spamy if you use it for regular request from an online system.