### PR TITLE
closes #48 and #45 added support to represent qsr fields as dictionaries, added support for ini files at start and at runtime

### DIFF
--- a/qsr_lib/cfg/defaults.ini
+++ b/qsr_lib/cfg/defaults.ini
@@ -1,0 +1,2 @@
+[arg_relations_distance]
+relations_and_values = {"0": 5., "1": 15., "2": 120.}

--- a/qsr_lib/scripts/example_ros_client.py
+++ b/qsr_lib/scripts/example_ros_client.py
@@ -40,6 +40,7 @@ if __name__ == "__main__":
     parser.add_argument("--quantisation_factor", help="quantisation factor for 0-states. Only QTC", type=float)
     parser.add_argument("--no_collapse", help="does not collapse similar adjacent states. Only QTC", action="store_true")
     parser.add_argument("--distance_threshold", help="distance threshold for qtcb <-> qtcc transition. Only QTCBC", type=float)
+    parser.add_argument("--future", help="QSRs as dict", action="store_true")
     args = parser.parse_args()
 
     client_node = rospy.init_node("qsr_lib_ros_client_example")
@@ -262,7 +263,7 @@ if __name__ == "__main__":
     # qsrlib_request_message = QSRlib_Request_Message(which_qsr=which_qsr, input_data=world, include_missing_data=True,
     #                                                 qsr_relations_and_values=qsr_relations_and_values, qsrs_for=[("o1", "o3"), ("o2", "o3")])
     qsrlib_request_message = QSRlib_Request_Message(which_qsr=which_qsr, input_data=world, include_missing_data=True,
-                                                    qsr_relations_and_values=qsr_relations_and_values)
+                                                    qsr_relations_and_values=qsr_relations_and_values, future=args.future)
     cln = QSRlib_ROS_Client()
     req = cln.make_ros_request_message(qsrlib_request_message)
     res = cln.request_qsrs(req)
@@ -274,5 +275,5 @@ if __name__ == "__main__":
         foo = str(t) + ": "
         for k, v in zip(out.qsrs.trace[t].qsrs.keys(), out.qsrs.trace[t].qsrs.values()):
             foo += str(k) + ":" + str(v.qsr) + "; "
+            # print(type(v.qsr))
         print(foo)
-

--- a/qsr_lib/scripts/example_ros_client.py
+++ b/qsr_lib/scripts/example_ros_client.py
@@ -41,6 +41,7 @@ if __name__ == "__main__":
     parser.add_argument("--no_collapse", help="does not collapse similar adjacent states. Only QTC", action="store_true")
     parser.add_argument("--distance_threshold", help="distance threshold for qtcb <-> qtcc transition. Only QTCBC", type=float)
     parser.add_argument("--future", help="QSRs as dict", action="store_true")
+    parser.add_argument("--ini", help="ini file", type=str)
     args = parser.parse_args()
 
     client_node = rospy.init_node("qsr_lib_ros_client_example")
@@ -262,8 +263,11 @@ if __name__ == "__main__":
     # uncomment this to test qsrs_for (and comment out the next line)
     # qsrlib_request_message = QSRlib_Request_Message(which_qsr=which_qsr, input_data=world, include_missing_data=True,
     #                                                 qsr_relations_and_values=qsr_relations_and_values, qsrs_for=[("o1", "o3"), ("o2", "o3")])
+    # qsrlib_request_message = QSRlib_Request_Message(which_qsr=which_qsr, input_data=world, include_missing_data=True,
+    #                                                 qsr_relations_and_values=qsr_relations_and_values, future=args.future)
     qsrlib_request_message = QSRlib_Request_Message(which_qsr=which_qsr, input_data=world, include_missing_data=True,
-                                                    qsr_relations_and_values=qsr_relations_and_values, future=args.future)
+                                                    future=args.future, ini=args.ini)
+
     cln = QSRlib_ROS_Client()
     req = cln.make_ros_request_message(qsrlib_request_message)
     res = cln.request_qsrs(req)

--- a/qsr_lib/src/qsrlib/qsrlib.py
+++ b/qsr_lib/src/qsrlib/qsrlib.py
@@ -30,7 +30,9 @@ class QSRlib_Response_Message(object):
 
 class QSRlib_Request_Message(object):
     def __init__(self, which_qsr="", input_data=None, qsrs_for=[], timestamp_request_made=None,
-                 start=0, finish=-1, objects_names=[], include_missing_data=True, qsr_relations_and_values={}):
+                 start=0, finish=-1, objects_names=[], include_missing_data=True, qsr_relations_and_values={},
+                 future=False):
+        self.future = future
         self.which_qsr = which_qsr
         self.input_data = None
         self.set_input_data(input_data=input_data, start=start, finish=finish, objects_names=objects_names)
@@ -39,7 +41,9 @@ class QSRlib_Request_Message(object):
         self.include_missing_data = include_missing_data
         self.qsr_relations_and_values = qsr_relations_and_values
 
-    def make(self, which_qsr, input_data, qsrs_for=[], timestamp_request_made=None):
+    def make(self, which_qsr, input_data, qsrs_for=[], timestamp_request_made=None, future=None):
+        if future:
+            self.future = future
         self.which_qsr = which_qsr
         self.input_data = self.set_input_data(input_data)
         self.qsrs_for = qsrs_for
@@ -135,7 +139,8 @@ class QSRlib(object):
                                                                                      include_missing_data=self.request_message.include_missing_data,
                                                                                      timestamp_request_received=self.timestamp_request_received,
                                                                                      qsrs_for=self.request_message.qsrs_for,
-                                                                                     qsr_relations_and_values=self.request_message.qsr_relations_and_values)
+                                                                                     qsr_relations_and_values=self.request_message.qsr_relations_and_values,
+                                                                                     future=self.request_message.future)
         except KeyError:
             print("ERROR (QSR_Lib.request_qsrs): it seems that the QSR you requested (" + self.request_message.which_qsr + ") is not implemented yet or has not been activated")
             world_qsr_trace = False

--- a/qsr_lib/src/qsrlib/qsrlib.py
+++ b/qsr_lib/src/qsrlib/qsrlib.py
@@ -31,7 +31,7 @@ class QSRlib_Response_Message(object):
 class QSRlib_Request_Message(object):
     def __init__(self, which_qsr="", input_data=None, qsrs_for=[], timestamp_request_made=None,
                  start=0, finish=-1, objects_names=[], include_missing_data=True, qsr_relations_and_values={},
-                 future=False):
+                 future=False, ini=None, dynamic_args=None):
         self.future = future
         self.which_qsr = which_qsr
         self.input_data = None
@@ -39,15 +39,20 @@ class QSRlib_Request_Message(object):
         self.qsrs_for = qsrs_for
         self.timestamp_request_made = datetime.now() if timestamp_request_made is None else timestamp_request_made
         self.include_missing_data = include_missing_data
-        self.qsr_relations_and_values = qsr_relations_and_values
+        self.qsr_relations_and_values = qsr_relations_and_values # should be more dynamic
+        self.ini = ini
+        self.dynamic_args = dynamic_args
 
-    def make(self, which_qsr, input_data, qsrs_for=[], timestamp_request_made=None, future=None):
+    def make(self, which_qsr, input_data, qsrs_for=[], timestamp_request_made=None, future=None, ini=None,
+             dynamic_args=None):
         if future:
             self.future = future
         self.which_qsr = which_qsr
         self.input_data = self.set_input_data(input_data)
         self.qsrs_for = qsrs_for
         self.timestamp_request_made = datetime.now() if timestamp_request_made is None else timestamp_request_made
+        self.ini = None
+        self.dynamic_args = None
 
     def set_input_data(self, input_data, start=0, finish=-1, objects_names=[]):
         error = False
@@ -140,7 +145,9 @@ class QSRlib(object):
                                                                                      timestamp_request_received=self.timestamp_request_received,
                                                                                      qsrs_for=self.request_message.qsrs_for,
                                                                                      qsr_relations_and_values=self.request_message.qsr_relations_and_values,
-                                                                                     future=self.request_message.future)
+                                                                                     future=self.request_message.future,
+                                                                                     ini=self.request_message.ini,
+                                                                                     dynamic_args=self.request_message.dynamic_args)
         except KeyError:
             print("ERROR (QSR_Lib.request_qsrs): it seems that the QSR you requested (" + self.request_message.which_qsr + ") is not implemented yet or has not been activated")
             world_qsr_trace = False

--- a/qsr_lib/src/qsrlib_qsrs/qsr_abstractclass.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_abstractclass.py
@@ -11,6 +11,9 @@
 
 from __future__ import print_function, division
 import abc
+import ConfigParser
+import rospkg
+import os
 
 
 class QSR_Abstractclass(object):
@@ -102,6 +105,17 @@ class QSR_Abstractclass(object):
         """
         return
 
+    def set_from_ini(self, ini):
+        if ini is None:
+            ini = os.path.join(rospkg.RosPack().get_path("qsr_lib"), "cfg/defaults.ini")
+        parser = ConfigParser.SafeConfigParser()
+        if len(parser.read(ini)) == 0:
+            raise IOError
+        self.custom_set_from_ini(parser)
+
+    @abc.abstractmethod
+    def custom_set_from_ini(self, parser):
+        return
 
     def handle_future(self, future, v, k=None):
         if future:

--- a/qsr_lib/src/qsrlib_qsrs/qsr_abstractclass.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_abstractclass.py
@@ -101,3 +101,12 @@ class QSR_Abstractclass(object):
         :return:
         """
         return
+
+
+    def handle_future(self, future, v, k=None):
+        if future:
+            if k is None:
+                raise ValueError("None qsr key")
+            return {k: v}
+        else:
+            return v

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_abstractclass.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_abstractclass.py
@@ -19,6 +19,7 @@ class QSR_Arg_Relations_Abstractclass(QSR_Abstractclass):
         self.qsr_relations_and_values = None
         self.all_possible_relations = None
         self.all_possible_values = None
+        self.qsr_keys = "argd"
 
     def __populate_possible_relations_and_values(self):
         ret_relations = []

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_abstractclass.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_abstractclass.py
@@ -34,7 +34,7 @@ class QSR_Arg_Relations_Abstractclass(QSR_Abstractclass):
         if type(qsr_relations_and_values) is not dict:
             raise ValueError("qsr_relations_and_values must be a dict")
         for k, v in qsr_relations_and_values.items():
-            if (type(k) is not str) and ((type(v) is not float) or (type(v) is not int)):
+            if (type(k) is not str) or ((type(v) is not float) and (type(v) is not int)):
                 raise ValueError("qsr_relations_and_values must be a dict of str:float|int")
         return True
 

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_distance.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_distance.py
@@ -7,13 +7,26 @@
 
 from __future__ import print_function, division
 import numpy as np
+import ConfigParser
 from qsr_arg_relations_abstractclass import QSR_Arg_Relations_Abstractclass
 from qsrlib_io.world_qsr_trace import *
 
 class QSR_Arg_Relations_Distance(QSR_Arg_Relations_Abstractclass):
-    def __init__(self):
+    def __init__(self, ini=None):
         super(QSR_Arg_Relations_Distance, self).__init__()
         self.qsr_type = "arg_relations_distance"
+        self.set_from_ini(ini=ini)
+
+    def custom_set_from_ini(self, parser):
+        try:
+            relations_and_values = parser.get(self.qsr_type, "relations_and_values")
+        except ConfigParser.NoOptionError:
+            raise
+        try:
+            relations_and_values = eval(relations_and_values)
+        except:
+            raise ValueError
+        self.set_qsr_relations_and_values(qsr_relations_and_values=relations_and_values)
 
     def custom_help(self):
         """Write your own help message function"""
@@ -49,10 +62,15 @@ class QSR_Arg_Relations_Distance(QSR_Arg_Relations_Abstractclass):
                         - input_data: World_Trace
         :return: World_QSR_Trace
         """
+        # optional set from ini
+        if kwargs["ini"]:
+            self.set_from_ini(kwargs["ini"])
+        # optional direct set
         if kwargs["qsr_relations_and_values"]:
             self.set_qsr_relations_and_values(qsr_relations_and_values=kwargs["qsr_relations_and_values"])
         if self.qsr_relations_and_values is None:
             raise ValueError("qsr_relations_and_values is uninitialized")
+        print("in make:", self.qsr_relations_and_values)
         input_data = kwargs["input_data"]
         include_missing_data = kwargs["include_missing_data"]
         ret = World_QSR_Trace(qsr_type=self.qsr_type)

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_distance.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_distance.py
@@ -70,7 +70,6 @@ class QSR_Arg_Relations_Distance(QSR_Arg_Relations_Abstractclass):
             self.set_qsr_relations_and_values(qsr_relations_and_values=kwargs["qsr_relations_and_values"])
         if self.qsr_relations_and_values is None:
             raise ValueError("qsr_relations_and_values is uninitialized")
-        print("in make:", self.qsr_relations_and_values)
         input_data = kwargs["input_data"]
         include_missing_data = kwargs["include_missing_data"]
         ret = World_QSR_Trace(qsr_type=self.qsr_type)

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_distance.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_distance.py
@@ -68,14 +68,15 @@ class QSR_Arg_Relations_Distance(QSR_Arg_Relations_Abstractclass):
                 for p in qsrs_for:
                     between = str(p[0]) + "," + str(p[1])
                     objs = (world_state.objects[p[0]], world_state.objects[p[1]])
-                    qsr = QSR(timestamp=timestamp, between=between, qsr=self.compute_qsr(objs))
+                    qsr = QSR(timestamp=timestamp, between=between,
+                              qsr=self.handle_future(kwargs["future"], self.__compute_qsr(objs), self.qsr_keys))
                     ret.add_qsr(qsr, timestamp)
             else:
                 if include_missing_data:
                     ret.add_empty_world_qsr_state(timestamp)
         return ret
 
-    def compute_qsr(self, objs):
+    def __compute_qsr(self, objs):
         if np.isnan(objs[0].z) or np.isnan(objs[1].z):
             d = np.sqrt(np.square(objs[0].x - objs[1].x) + np.square(objs[0].y - objs[1].y))
         else:

--- a/qsr_lib/src/qsrlib_qsrs/qsr_cone_direction_bounding_boxes_centroid_2d.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_cone_direction_bounding_boxes_centroid_2d.py
@@ -21,6 +21,9 @@ class QSR_Cone_Direction_Bounding_Boxes_Centroid_2D(QSR_Abstractclass):
         self.qsr_type = "cone_direction_bounding_boxes_centroid_2d"  # must be the same that goes in the QSR_Lib.__const_qsrs_available
         self.all_possible_relations = ["north", "north-east", "east", "south-east", "south", "south-west", "west", "north-west", "same", "unknown"]
 
+    def custom_set_from_ini(self, parser):
+        pass
+
     def custom_help(self):
         """Write your own help message function"""
         print("where,\nx1, y2: the xy-coords of the top-left corner of the rectangle\nx2, y2: the xy-coords of the bottom-right corner of the rectangle")

--- a/qsr_lib/src/qsrlib_qsrs/qsr_qtc_simplified_abstractclass.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_qtc_simplified_abstractclass.py
@@ -24,6 +24,9 @@ class QSR_QTC_Simplified_Abstractclass(QSR_Abstractclass):
     def __init__(self):
         self.qtc_type = ""
 
+    def custom_set_from_ini(self, parser):
+        pass
+
     def return_all_possible_state_combinations(self):
         """Method that returns all possible state combinations for the qtc_type
         defined for this calss instance.

--- a/qsr_lib/src/qsrlib_qsrs/qsr_rcc3_rectangle_bounding_boxes_2d.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_rcc3_rectangle_bounding_boxes_2d.py
@@ -24,6 +24,9 @@ class QSR_RCC3_Rectangle_Bounding_Boxes_2D(QSR_Abstractclass):
         self.qsr_keys = "rcc3"
         self.all_possible_relations = ["dc", "po", "o"]
 
+    def custom_set_from_ini(self, parser):
+        pass
+
     def custom_help(self):
         """Write your own help message function"""
         print("where,\nx1, y2: the xy-coords of the top-left corner of the rectangle\nx2, y2: the xy-coords of the bottom-right corner of the rectangle")

--- a/qsr_lib/src/qsrlib_qsrs/qsr_rcc3_rectangle_bounding_boxes_2d.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_rcc3_rectangle_bounding_boxes_2d.py
@@ -21,6 +21,7 @@ class QSR_RCC3_Rectangle_Bounding_Boxes_2D(QSR_Abstractclass):
     """Make default QSRs and provide an example for others"""
     def __init__(self):
         self.qsr_type = "rcc3_rectangle_bounding_boxes_2d"  # must be the same that goes in the QSR_Lib.__const_qsrs_available
+        self.qsr_keys = "rcc3"
         self.all_possible_relations = ["dc", "po", "o"]
 
     def custom_help(self):
@@ -71,7 +72,8 @@ class QSR_RCC3_Rectangle_Bounding_Boxes_2D(QSR_Abstractclass):
                     between = str(p[0]) + "," + str(p[1])
                     bb1 = world_state.objects[p[0]].return_bounding_box_2d()
                     bb2 = world_state.objects[p[1]].return_bounding_box_2d()
-                    qsr = QSR(timestamp=timestamp, between=between, qsr=self.__compute_qsr(bb1, bb2))
+                    qsr = QSR(timestamp=timestamp, between=between,
+                              qsr=self.handle_future(kwargs["future"], self.__compute_qsr(bb1, bb2), self.qsr_keys))
                     ret.add_qsr(qsr, timestamp)
             else:
                 if include_missing_data:

--- a/qsr_lib/src/qsrlib_qsrs/qsr_rcc8_rectangle_bounding_boxes_2d.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_rcc8_rectangle_bounding_boxes_2d.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-"""
+"""RCC8, based upon RCC3
+
 :Author: Peter Lightbody <plightbody@lincoln.ac.uk>
+:Author: Yiannis Gatsoulis <y.gatsoulis@leeds.ac.uk>
 :Organization: University of Lincoln
 :Date: 12 May 2015
 :Version: 0.1
@@ -18,6 +20,7 @@ class QSR_RCC8_Rectangle_Bounding_Boxes_2D(QSR_Abstractclass):
     """Make default QSRs and provide an example for others"""
     def __init__(self):
         self.qsr_type = "rcc8_rectangle_bounding_boxes_2d"  # must be the same that goes in the QSR_Lib.__const_qsrs_available
+        self.qsr_keys = "rcc8"
 #         'dc'     bb1 is disconnected from bb2
 #         'ec'     bb1 is externally connected with bb2
 #         'po'     bb1 partially overlaps bb2
@@ -76,7 +79,8 @@ class QSR_RCC8_Rectangle_Bounding_Boxes_2D(QSR_Abstractclass):
                     between = str(p[0]) + "," + str(p[1])
                     bb1 = world_state.objects[p[0]].return_bounding_box_2d()
                     bb2 = world_state.objects[p[1]].return_bounding_box_2d()
-                    qsr = QSR(timestamp=timestamp, between=between, qsr=self.__compute_qsr(bb1, bb2))
+                    qsr = QSR(timestamp=timestamp, between=between,
+                              qsr=self.handle_future(kwargs["future"], self.__compute_qsr(bb1, bb2), self.qsr_keys))
                     ret.add_qsr(qsr, timestamp)
             else:
                 if include_missing_data:

--- a/qsr_lib/src/qsrlib_qsrs/qsr_rcc8_rectangle_bounding_boxes_2d.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_rcc8_rectangle_bounding_boxes_2d.py
@@ -31,6 +31,9 @@ class QSR_RCC8_Rectangle_Bounding_Boxes_2D(QSR_Abstractclass):
 #         'ntppi'  bb2 is a non-tangential proper part of bb1
         self.all_possible_relations = ["dc", "ec", "po", "eq", "tpp", "ntpp", "tppi", "ntppi"]
 
+    def custom_set_from_ini(self, parser):
+        pass
+
     def custom_help(self):
         """Write your own help message function"""
         print("where,\nx1, y2: the xy-coords of the top-left corner of the rectangle\nx2, y2: the xy-coords of the bottom-right corner of the rectangle")


### PR DESCRIPTION
** ***NOTE UPDATE*** **

**Added support to represent qsr fields as dictionaries.**

The default is still strings. To enable this you need to set to the `request_message` constructor or in make `future=True`. To test it in the `ros_example_client` just pass `--future`.

I have updated the QSRs except from QTC as it is not possible without having the pending pull requests merged.

At some point I would like to deprecate the string representation. But, only when everyone is happy. So for future please use the dictionary format.

**Added support for ini files at startup and at runtime**
See example in `example_ros_client`, `arg_distance` qsr and `cfg/defaults.ini`

If somebody could test these please.