### PR TITLE
Trace from list

### DIFF
--- a/qsr_lib/src/qsrlib_io/world_trace.py
+++ b/qsr_lib/src/qsrlib_io/world_trace.py
@@ -63,12 +63,13 @@ class World_Trace(object):
             ret = [str(i) for i in ret]
         return ret
 
-    def add_object_track_from_list(self, obj_name, track, t0=0):
+    def add_object_track_from_list(self, obj_name, track, t0=0, **kwargs):
         """Add the objects data to the world_trace from a list of values
 
         :param obj_name: name of object
         :param track: list/tuple of values as [[x1, y1, w1, l1], [x2, y2, w2, l2], ...] or [[x1, y1], [x2, y2], ...]
         :param t0: time offset
+        :param kwargs:
         """
         object_state_series = []
         for t in range(len(track)):
@@ -82,7 +83,9 @@ class World_Trace(object):
                 length = track[t][3]
             except IndexError:
                 length = float('nan')
-            object_state_series.append(Object_State(name=obj_name, timestamp=t+t0, x=x, y=y, width=width, length=length))
+            object_state_series.append(Object_State(name=obj_name, timestamp=t+t0,
+                                                    x=x, y=y, width=width, length=length,
+                                                    **kwargs))
         self.add_object_state_series(object_state_series)
 
     def add_object_state_to_trace(self, object_state, timestamp=None):

--- a/qsr_lib/src/qsrlib_io/world_trace.py
+++ b/qsr_lib/src/qsrlib_io/world_trace.py
@@ -63,6 +63,28 @@ class World_Trace(object):
             ret = [str(i) for i in ret]
         return ret
 
+    def add_object_track_from_list(self, obj_name, track, t0=0):
+        """Add the objects data to the world_trace from a list of values
+
+        :param obj_name: name of object
+        :param track: list/tuple of values as [[x1, y1, w1, l1], [x2, y2, w2, l2], ...] or [[x1, y1], [x2, y2], ...]
+        :param t0: time offset
+        """
+        object_state_series = []
+        for t in range(len(track)):
+            x = track[t][0]
+            y = track[t][1]
+            try:
+                width = track[t][2]
+            except IndexError:
+                width = float('nan')
+            try:
+                length = track[t][3]
+            except IndexError:
+                length = float('nan')
+            object_state_series.append(Object_State(name=obj_name, timestamp=t+t0, x=x, y=y, width=width, length=length))
+        self.add_object_state_series(object_state_series)
+
     def add_object_state_to_trace(self, object_state, timestamp=None):
         if not timestamp:
             timestamp = object_state.timestamp


### PR DESCRIPTION
Takes a list of lists/tuples representing the trace of an object and adds them in a world_trace.

Simple to debug, add the following in the end of [`world_trace.py`](https://github.com/strands-project/strands_qsr_lib/blob/master/qsr_lib/src/qsrlib_io/world_trace.py) and then just run the file.
```python
if __name__ == '__main__':
    world_trace = World_Trace()
    w = 1
    l = 1
    o1 = [(1,1,w,l), (2,1,w,l), (3,1,w,l)]
    o2 = [(1,1,w,l), (1,2,w,l), (1,3,w,l)]
    o3 = [(0,0), (0,0)]

    world_trace.add_object_track_from_list(obj_name="a", track=o1)
    world_trace.add_object_track_from_list(obj_name="b", track=o2)
    world_trace.add_object_track_from_list(obj_name="c", track=o3, t0=2)

    for t in world_trace.get_sorted_timestamps():
        print("---\n%d" %t)
        print(world_trace.trace[t].objects.keys())
        for k, v in world_trace.trace[t].objects.items():
            print(k, (v.x, v.y, v.width, v.length))
        print()
```