### PR TITLE
Fixing qtcbc collapse bug

### DIFF
--- a/qsr_lib/src/qsrlib_qsrs/qsr_qtc_bc_simplified.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_qtc_bc_simplified.py
@@ -129,7 +129,7 @@ class QSR_QTC_BC_Simplified(QSR_QTC_Simplified_Abstractclass):
                     raise Exception("'no_collapse' and 'validate' have to be boolean values.")
 
                 qtc_sequence = self._create_bc_chain(qtc_sequence, distances, distance_threshold)
-                if no_collapse:
+                if not no_collapse:
                     qtc_sequence = self._collapse_similar_states(qtc_sequence)
                 if validate:
                     qtc_sequence = self._validate_qtc_sequence(qtc_sequence)


### PR DESCRIPTION
Stupid mistake I found while creating #68 
The behaviour when using `no_callapse` is inverted for qtc_bc. Of course you always find these after a re-release ;)
Hence the new test.