### PR TITLE
fixes return_bounding_box_2d for nan width or length

### DIFF
--- a/qsr_lib/src/qsrlib_io/world_trace.py
+++ b/qsr_lib/src/qsrlib_io/world_trace.py
@@ -24,16 +24,28 @@ class Object_State(object):
         self.x = x
         self.y = y
         self.z = z
+        # self.length = float('nan')  # y size
+        # self.width = float('nan')  # x size
+        # self.height = float('nan')  # z size
+        self.set_length_width_height(length=length, width=width, height=height)
         self.roll = roll
         self.pitch = pitch
         self.yaw = yaw
-        self.length = length # y size
-        self.width = width # x size
-        self.height = height # z size
+
         self.args = args
         self.kwargs = kwargs
 
+    def set_length_width_height(self, length=float('nan'), width=float('nan'), height=float('nan')):
+        if length < 0 or width < 0 or height < 0:
+            raise ValueError("Object length, width and height cannot be negative; leave them to default values if unset")
+        else:
+            self.width = width  # x size
+            self.length = length  # y size
+            self.height = height  # z size
+
     def return_bounding_box_2d(self, minimal_width=0, minimal_length=0):
+        if self.width < 0 or self.length < 0:
+            raise ValueError("Object width and length cannot be negative")
         width = minimal_width if isnan(self.width) else self.width
         length = minimal_length if isnan(self.length) else self.length
         return [self.x-width/2, self.y-length/2, self.x+width/2, self.y+length/2]

--- a/qsr_lib/src/qsrlib_io/world_trace.py
+++ b/qsr_lib/src/qsrlib_io/world_trace.py
@@ -10,6 +10,7 @@
 """
 
 from __future__ import print_function, division
+from numpy import isnan
 import copy
 
 class Object_State(object):
@@ -32,11 +33,10 @@ class Object_State(object):
         self.args = args
         self.kwargs = kwargs
 
-    def return_bounding_box_2d(self):
-        if self.width <= 0 or self.length <= 0:
-            print("ERROR: can't compute bounding box, width or height has no positive value")
-            return []
-        return [self.x-self.width/2, self.y-self.length/2, self.x+self.width/2, self.y+self.length/2]
+    def return_bounding_box_2d(self, minimal_width=2, minimal_length=2):
+        width = minimal_width if (isnan(self.width) or self.width == 0) else self.width
+        length = minimal_length if (isnan(self.length) or self.length == 0) else self.length
+        return [self.x-width/2, self.y-length/2, self.x+width/2, self.y+length/2]
 
 
 class World_State(object):

--- a/qsr_lib/src/qsrlib_io/world_trace.py
+++ b/qsr_lib/src/qsrlib_io/world_trace.py
@@ -33,9 +33,9 @@ class Object_State(object):
         self.args = args
         self.kwargs = kwargs
 
-    def return_bounding_box_2d(self, minimal_width=2, minimal_length=2):
-        width = minimal_width if (isnan(self.width) or self.width == 0) else self.width
-        length = minimal_length if (isnan(self.length) or self.length == 0) else self.length
+    def return_bounding_box_2d(self, minimal_width=0, minimal_length=0):
+        width = minimal_width if isnan(self.width) else self.width
+        length = minimal_length if isnan(self.length) else self.length
         return [self.x-width/2, self.y-length/2, self.x+width/2, self.y+length/2]
 
 


### PR DESCRIPTION
If width or length is ~~0~~nan then it returns a ~~minimal~~ 0 bounding box (ie. (x1, y1, x2, y2) with x1=x2 and y1=y2).

Closes #70 