### PR TITLE
[qsr_lib] Enabling request for multiple QSRs in the same service call using future

### DIFF
--- a/qsr_lib/scripts/example_ros_client.py
+++ b/qsr_lib/scripts/example_ros_client.py
@@ -34,7 +34,8 @@ if __name__ == "__main__":
                "qtcbc": "qtc_bc_simplified",
                "rcc3a": "rcc3_rectangle_bounding_boxes_2d",
                "arg_distance": "arg_relations_distance",
-                "mos": "moving_or_stationary"}
+                "mos": "moving_or_stationary",
+                "multiple": ("cone_direction_bounding_boxes_centroid_2d", "rcc3_rectangle_bounding_boxes_2d", "moving_or_stationary", "qtc_b_simplified")}
 
     parser = argparse.ArgumentParser()
     parser.add_argument("qsr", help="choose qsr: %s" % options.keys(), type=str)
@@ -286,6 +287,17 @@ if __name__ == "__main__":
 
             world.add_object_state_series(o1)
             world.add_object_state_series(o2)
+
+    elif which_qsr_argv == "multiple":
+        traj = [Object_State(name="traj", timestamp=0, x=1., y=1., width=5., length=8.),
+            Object_State(name="traj", timestamp=1, x=1., y=2., width=5., length=8.)]
+        o1 = [Object_State(name="o1", timestamp=0, x=11., y=1., width=5., length=8.),
+              Object_State(name="o1", timestamp=1, x=11., y=2., width=5., length=8.)]
+        o2 = [Object_State(name="o2", timestamp=0, x=11., y=1., width=5., length=8.),
+              Object_State(name="o2", timestamp=1, x=11., y=2., width=5., length=8.)]
+
+        world.add_object_state_series(traj)
+        world.add_object_state_series(o1)
 
     # uncomment this to test qsrs_for (and comment out the next line)
     # qsrlib_request_message = QSRlib_Request_Message(which_qsr=which_qsr, input_data=world, include_missing_data=True,

--- a/qsr_lib/scripts/example_ros_client.py
+++ b/qsr_lib/scripts/example_ros_client.py
@@ -34,8 +34,11 @@ if __name__ == "__main__":
                "qtcbc": "qtc_bc_simplified",
                "rcc3a": "rcc3_rectangle_bounding_boxes_2d",
                "arg_distance": "arg_relations_distance",
-                "mos": "moving_or_stationary",
-                "multiple": ("cone_direction_bounding_boxes_centroid_2d", "rcc3_rectangle_bounding_boxes_2d", "moving_or_stationary", "qtc_b_simplified")}
+                "mos": "moving_or_stationary"}
+
+    # options["multiple"] = ("cone_direction_bounding_boxes_centroid_2d", "rcc3_rectangle_bounding_boxes_2d", "moving_or_stationary", "qtc_b_simplified")
+    options["multiple"] = options.values()
+    options["multiple"].pop(options["multiple"].index("arg_relations_distance"))
 
     parser = argparse.ArgumentParser()
     parser.add_argument("qsr", help="choose qsr: %s" % options.keys(), type=str)

--- a/qsr_lib/src/qsrlib/qsrlib.py
+++ b/qsr_lib/src/qsrlib/qsrlib.py
@@ -171,12 +171,12 @@ class QSRlib(object):
         # Checking if future is True when a list of QSRs is given.
         # If not, print error as the string results do not support multiple
         # QSRs at the same time
-        if not request_message.future and (type(request_message.which_qsr) == list or type(request_message.which_qsr) == tuple):
+        if not request_message.future and (isinstance(request_message.which_qsr, list) or isinstance(request_message.which_qsr, tuple)):
             print("ERROR (QSR_Lib.request_qsrs): Using a", type(request_message.which_qsr), "of qsrs:", request_message.which_qsr, "is only supported when using future: future = True")
             world_qsr_traces = False
         else:
             # which_qsrs should always be iterable, even it is only a string, to enable the loop
-            which_qsrs = request_message.which_qsr if type(request_message.which_qsr) == list or type(request_message.which_qsr) == tuple else [request_message.which_qsr]
+            which_qsrs = request_message.which_qsr if isinstance(request_message.which_qsr, list) or isinstance(request_message.which_qsr, tuple) else [request_message.which_qsr]
             for which_qsr in which_qsrs:
                 try:
                     world_qsr_traces.append(self.__qsrs_active[which_qsr].get(input_data=request_message.input_data,
@@ -193,7 +193,7 @@ class QSRlib(object):
 
         if world_qsr_traces:
             # If the input was a list of QSRs, merge the results
-            if request_message.future and (type(request_message.which_qsr) == list or type(request_message.which_qsr) == tuple):
+            if request_message.future and (isinstance(request_message.which_qsr, list) or isinstance(request_message.which_qsr, tuple)):
                 world_qsr_trace = self.__merge_world_qsr_traces(world_qsr_traces, ",".join(request_message.which_qsr))
             else: # Just take the first because the list will only contain that one element
                 world_qsr_trace = world_qsr_traces[0]


### PR DESCRIPTION
When `which_qsr` is a list or tuple and `future` is `True` the server will compute all the given QSRs for the presented objects and return them in a dictionary. I made comments in the code that hopefully explain how it works. 
Merging function provided by @yianni 

The example client has now a new "QSR" called `multiple` which creates the result for a predefined list of QSRs. If it is called with:
```
rosrun qsr_lib example_ros_client.py multiple
```
this will fail and print an error via the server. When run with
```
rosrun qsr_lib example_ros_client.py multiple --future
```
this will return the correct result.

I tested this also for backwards compatibility but might have missed something. So please check.

Closes #83 

This PR also includes a minor fix which closes #84 