### PR TITLE
Adding namespace to dynamic args

### DIFF
--- a/qsr_lib/scripts/example_ros_client.py
+++ b/qsr_lib/scripts/example_ros_client.py
@@ -29,12 +29,12 @@ if __name__ == "__main__":
                "rcc3": "rcc3_rectangle_bounding_boxes_2d",
                "rcc8": "rcc8_rectangle_bounding_boxes_2d",
                "coneDir": "cone_direction_bounding_boxes_centroid_2d",
-               "qtcb": "qtc_b_simplified",
-               "qtcc": "qtc_c_simplified",
-               "qtcbc": "qtc_bc_simplified",
+               "qtcbs": "qtc_b_simplified",
+               "qtccs": "qtc_c_simplified",
+               "qtcbcs": "qtc_bc_simplified",
                "rcc3a": "rcc3_rectangle_bounding_boxes_2d",
-               "arg_distance": "arg_relations_distance",
-                "mos": "moving_or_stationary"}
+               "argd": "arg_relations_distance",
+               "mos": "moving_or_stationary"}
 
     # options["multiple"] = ("cone_direction_bounding_boxes_centroid_2d", "rcc3_rectangle_bounding_boxes_2d", "moving_or_stationary", "qtc_b_simplified")
     options["multiple"] = options.values()
@@ -107,7 +107,7 @@ if __name__ == "__main__":
         world.add_object_state_series(o4)
 
     elif which_qsr_argv == "mos":
-        dynamic_args = {"quantisation_factor": args.quantisation_factor}
+        dynamic_args = {which_qsr_argv: {"quantisation_factor": args.quantisation_factor}}
 
         o1 = [Object_State(name="o1", timestamp=0, x=1., y=1., width=5., length=8.),
               Object_State(name="o1", timestamp=1, x=2., y=1., width=5., length=8.),
@@ -121,7 +121,10 @@ if __name__ == "__main__":
         world.add_object_state_series(o1)
         world.add_object_state_series(o2)
 
-    elif which_qsr_argv == "arg_distance":
+    elif which_qsr_argv == "argd":
+        qsr_relations_and_values = {"0": 5., "1": 15., "2": 100.}
+        dynamic_args = {which_qsr_argv: {"qsr_relations_and_values": qsr_relations_and_values}}
+
         o1 = [Object_State(name="o1", timestamp=0, x=1., y=1., width=5., length=8.),
               Object_State(name="o1", timestamp=1, x=1., y=2., width=5., length=8.),
               Object_State(name="o1", timestamp=2, x=1., y=2., width=5., length=8.)]
@@ -137,9 +140,6 @@ if __name__ == "__main__":
         world.add_object_state_series(o1)
         world.add_object_state_series(o2)
         world.add_object_state_series(o3)
-
-        qsr_relations_and_values = {"0": 5., "1": 15., "2": 100.}
-        dynamic_args = {"qsr_relations_and_values": qsr_relations_and_values}
 
     elif which_qsr_argv == "coneDir":
         o1 = [Object_State(name="o1", timestamp=0, x=5., y=5., width=2., length=2.),
@@ -173,12 +173,12 @@ if __name__ == "__main__":
         world.add_object_state_series(o1)
         world.add_object_state_series(o2)
 
-    elif which_qsr_argv == "qtcb":
-        dynamic_args = {
+    elif which_qsr_argv == "qtcbs":
+        dynamic_args = {which_qsr_argv: {
             "quantisation_factor": args.quantisation_factor,
             "validate": args.validate,
             "no_collapse": args.no_collapse
-        }
+        }}
 
         if args.input:
             ob = []
@@ -212,12 +212,12 @@ if __name__ == "__main__":
             world.add_object_state_series(o1)
             world.add_object_state_series(o2)
 
-    elif which_qsr_argv == "qtcc":
-        dynamic_args = {
+    elif which_qsr_argv == "qtccs":
+        dynamic_args = {which_qsr_argv: {
             "quantisation_factor": args.quantisation_factor,
             "validate": args.validate,
             "no_collapse": args.no_collapse
-        }
+        }}
 
         if args.input:
             ob = []
@@ -251,13 +251,13 @@ if __name__ == "__main__":
             world.add_object_state_series(o1)
             world.add_object_state_series(o2)
 
-    elif which_qsr_argv == "qtcbc":
-        dynamic_args = {
+    elif which_qsr_argv == "qtcbcs":
+        dynamic_args = {which_qsr_argv: {
             "quantisation_factor": args.quantisation_factor,
             "distance_threshold": args.distance_threshold,
             "validate": args.validate,
             "no_collapse": args.no_collapse
-        }
+        }}
 
         if args.input:
             ob = []

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_distance.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_distance.py
@@ -81,6 +81,12 @@ class QSR_Arg_Relations_Distance(QSR_Arg_Relations_Abstractclass):
         try:
             if kwargs["dynamic_args"]["qsr_relations_and_values"]:
                 self.set_qsr_relations_and_values(qsr_relations_and_values=kwargs["dynamic_args"]["qsr_relations_and_values"])
+                print("Warning: This feature is deprecated, use dynamic_args with the namespace '%s' on your request message instead" % self.qsr_keys)
+        except:
+            pass
+        try:
+            if kwargs["dynamic_args"][self.qsr_keys]["qsr_relations_and_values"]:
+                self.set_qsr_relations_and_values(qsr_relations_and_values=kwargs["dynamic_args"][self.qsr_keys]["qsr_relations_and_values"])
         except:
             pass
         # print(self.qsr_relations_and_values)  # dbg

--- a/qsr_lib/src/qsrlib_qsrs/qsr_moving_or_stationary.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_moving_or_stationary.py
@@ -60,10 +60,18 @@ class QSR_Moving_or_Stationary(QSR_Abstractclass):
         """
         input_data = kwargs["input_data"]
         include_missing_data = kwargs["include_missing_data"]
+        quantisation_factor = 0.0
         try:
             quantisation_factor = float(kwargs["dynamic_args"]["quantisation_factor"])
+            print("Warning: This feature is deprecated, use dynamic_args with the namespace '%s' on your request message instead" % self.qsr_keys)
         except:
-            quantisation_factor = 0.0
+            pass
+
+        try:
+            quantisation_factor = float(kwargs["dynamic_args"][self.qsr_keys]["quantisation_factor"])
+        except:
+            pass
+
         ret = World_QSR_Trace(qsr_type=self.qsr_type)
         ts = input_data.get_sorted_timestamps()
         for t, tp in zip(ts[1:], ts):

--- a/qsr_lib/src/qsrlib_qsrs/qsr_qtc_bc_simplified.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_qtc_bc_simplified.py
@@ -46,12 +46,7 @@ class QSR_QTC_BC_Simplified(QSR_QTC_Simplified_Abstractclass):
             "no_collapse": False
         }
 
-        try:
-            if kwargs["dynamic_args"]:
-                for k, v in kwargs["dynamic_args"].items():
-                    parameters[k] = v
-        except:
-            print "No parameters found, will use default parameters: ", parameters
+        parameters = self._get_parameters(parameters, **kwargs)
 
         if kwargs["qsrs_for"]:
             qsrs_for, error_found = self.check_qsrs_for_data_exist(sorted(input_data.trace[timestamps[0]].objects.keys()), kwargs["qsrs_for"])

--- a/qsr_lib/src/qsrlib_qsrs/qsr_qtc_simplified_abstractclass.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_qtc_simplified_abstractclass.py
@@ -20,9 +20,11 @@ class QSR_QTC_Simplified_Abstractclass(QSR_Abstractclass):
     """Abstract class for the QSR makers"""
     __metaclass__ = ABCMeta
 
+    __qsr_keys = "qtcs"
+
     def __init__(self):
         self.qtc_type = ""
-        self.qsr_keys = "qtcs"
+        self.qsr_keys = ""
 
     def custom_set_from_config_file(self, document):
         pass
@@ -349,6 +351,30 @@ class QSR_QTC_Simplified_Abstractclass(QSR_Abstractclass):
                 error_found = True
         return qsrs_for, error_found
 
+    def _get_parameters(self, default, **kwargs):
+        try: # Depricated
+            if kwargs["dynamic_args"]:
+                print("Warning: This feature is deprecated, use dynamic_args with the namespace '%s' on your request message instead" % self.qsr_keys)
+                for k, v in kwargs["dynamic_args"][self.__qsr_keys].items():
+                    default[k] = v
+        except:
+            pass
+
+        try: # General case
+            if kwargs["dynamic_args"][self.__qsr_keys]:
+                for k, v in kwargs["dynamic_args"][self.__qsr_keys].items():
+                    default[k] = v
+        except:
+            pass
+
+        try: # Parameters for a specific variant
+            if kwargs["dynamic_args"][self.qsr_keys]:
+                for k, v in kwargs["dynamic_args"][self.qsr_keys].items():
+                    default[k] = v
+        except:
+            pass
+
+        return default
 
     def make(self, *args, **kwargs):
         """Make the QSRs
@@ -375,12 +401,7 @@ class QSR_QTC_Simplified_Abstractclass(QSR_Abstractclass):
             "no_collapse": False
         }
 
-        try:
-            if kwargs["dynamic_args"]:
-                for k, v in kwargs["dynamic_args"].items():
-                    parameters[k] = v
-        except:
-            print "No parameters found, will use default parameters: ", parameters
+        parameters = self._get_parameters(parameters, **kwargs)
 
         if qsrs_for:
             for p in qsrs_for:

--- a/qsr_lib/tests/qtc_tester.py
+++ b/qsr_lib/tests/qtc_tester.py
@@ -18,20 +18,20 @@ from qsrlib_ros.qsrlib_ros_client import QSRlib_ROS_Client
 
 class TestQTC(unittest.TestCase):
     TEST_FILE = find_resource(PKG, 'qtc.csv')[0]
-    options = {"qtcb": "qtc_b_simplified",
-               "qtcc": "qtc_c_simplified",
-               "qtcbc": "qtc_bc_simplified"}
-    dynamic_args = {
+    options = {"qtcbs": "qtc_b_simplified",
+               "qtccs": "qtc_c_simplified",
+               "qtcbcs": "qtc_bc_simplified"}
+    dynamic_args = {"qtcs": {
         "quantisation_factor": 0.01,
         "validate": True,
         "no_collapse": False,
         "distance_threshold": 1.2
-    }
+    }}
 
     correct = {
-        "qtcb": [{'qtcbs': '-,-'}, {'qtcbs': '-,0'}, {'qtcbs': '0,0'}, {'qtcbs': '0,+'}, {'qtcbs': '+,+'}],
-        "qtcc": [{'qtccs': '-,-,0,0'}, {'qtccs': '-,-,+,0'}, {'qtccs': '-,0,+,0'}, {'qtccs': '-,0,+,+'}, {'qtccs': '0,0,+,+'}, {'qtccs': '0,0,+,0'}, {'qtccs': '0,+,+,0'}, {'qtccs': '+,+,+,0'}, {'qtccs': '+,+,0,0'}],
-        "qtcbc": [{'qtcbcs': '-,-'}, {'qtcbcs': '-,0'}, {'qtcbcs': '-,0,+,0'}, {'qtcbcs': '-,0,+,+'}, {'qtcbcs': '0,0,+,+'}, {'qtcbcs': '0,0,+,0'}, {'qtcbcs': '0,+,+,0'}, {'qtcbcs': '+,+,+,0'}, {'qtcbcs': '+,+'}]
+        "qtcbs": [{'qtcbs': '-,-'}, {'qtcbs': '-,0'}, {'qtcbs': '0,0'}, {'qtcbs': '0,+'}, {'qtcbs': '+,+'}],
+        "qtccs": [{'qtccs': '-,-,0,0'}, {'qtccs': '-,-,+,0'}, {'qtccs': '-,0,+,0'}, {'qtccs': '-,0,+,+'}, {'qtccs': '0,0,+,+'}, {'qtccs': '0,0,+,0'}, {'qtccs': '0,+,+,0'}, {'qtccs': '+,+,+,0'}, {'qtccs': '+,+,0,0'}],
+        "qtcbcs": [{'qtcbcs': '-,-'}, {'qtcbcs': '-,0'}, {'qtcbcs': '-,0,+,0'}, {'qtcbcs': '-,0,+,+'}, {'qtcbcs': '0,0,+,+'}, {'qtcbcs': '0,0,+,0'}, {'qtcbcs': '0,+,+,0'}, {'qtcbcs': '+,+,+,0'}, {'qtcbcs': '+,+'}]
     }
 
 
@@ -90,28 +90,28 @@ class TestQTC(unittest.TestCase):
         return [x.values()[0] for x in array]
 
     def test_qtcb(self):
-        res = self._create_qsr("qtcb")
-        self.assertEqual(res, self._to_strings(self.correct["qtcb"]))
+        res = self._create_qsr("qtcbs")
+        self.assertEqual(res, self._to_strings(self.correct["qtcbs"]))
 
     def test_qtcb_future(self):
-        res = self._create_qsr("qtcb", future=True)
-        self.assertEqual(res, self.correct["qtcb"])
+        res = self._create_qsr("qtcbs", future=True)
+        self.assertEqual(res, self.correct["qtcbs"])
 
     def test_qtcc(self):
-        res = self._create_qsr("qtcc")
-        self.assertEqual(res, self._to_strings(self.correct["qtcc"]))
+        res = self._create_qsr("qtccs")
+        self.assertEqual(res, self._to_strings(self.correct["qtccs"]))
 
     def test_qtcc_future(self):
-        res = self._create_qsr("qtcc", future=True)
-        self.assertEqual(res, self.correct["qtcc"])
+        res = self._create_qsr("qtccs", future=True)
+        self.assertEqual(res, self.correct["qtccs"])
 
     def test_qtcbc(self):
-        res = self._create_qsr("qtcbc")
-        self.assertEqual(res, self._to_strings(self.correct["qtcbc"]))
+        res = self._create_qsr("qtcbcs")
+        self.assertEqual(res, self._to_strings(self.correct["qtcbcs"]))
 
     def test_qtcbc_future(self):
-        res = self._create_qsr("qtcbc", future=True)
-        self.assertEqual(res, self.correct["qtcbc"])
+        res = self._create_qsr("qtcbcs", future=True)
+        self.assertEqual(res, self.correct["qtcbcs"])
 
 
 


### PR DESCRIPTION
Closes #90 

* Adding namespace to `mos`: closes #91 
* Adding namespace to `qtcs`: closes #92 
 * Namespace `qtcs` is valid for all QTCs but can be overridden for a specific variant: `qtcbs`,`qtccs`, or `qtcbcs`
* Adding namespace to `argd`: closes #93 

The example ros client now uses the new namespace format and the correct qsr key, i.e. `argd` instead of `arg_distance`, `qtcbs` instead of `qtcb`, `qtccs` instead of `qtcc`, and `qtcbcs` instead of `qtcbc`

The use of no namespace still works but prints a deprecated warning on the server.