### PR TITLE
[qsr_lib] Adding a probabilistic version of arg_distance

### DIFF
--- a/qsr_lib/scripts/example_ros_client.py
+++ b/qsr_lib/scripts/example_ros_client.py
@@ -34,6 +34,7 @@ if __name__ == "__main__":
                "qtcbcs": "qtc_bc_simplified",
                "rcc3a": "rcc3_rectangle_bounding_boxes_2d",
                "argd": "arg_relations_distance",
+               "argprobd": "arg_prob_relations_distance",
                "mos": "moving_or_stationary"}
 
     # options["multiple"] = ("cone_direction_bounding_boxes_centroid_2d", "rcc3_rectangle_bounding_boxes_2d", "moving_or_stationary", "qtc_b_simplified")
@@ -122,8 +123,8 @@ if __name__ == "__main__":
         world.add_object_state_series(o1)
         world.add_object_state_series(o2)
 
-    elif which_qsr_argv == "argd":
-        qsr_relations_and_values = {"0": 5., "1": 15., "2": 100.}
+    elif which_qsr_argv == "argd" or which_qsr_argv == "argprobd":
+        qsr_relations_and_values = {"0": 5., "1": 15., "2": 100.} if which_qsr_argv == "argd" else {"0": (2.5,2.5/2), "1": (7.5,7.5/2), "2": [50,50/2]}
         dynamic_args = {which_qsr_argv: {"qsr_relations_and_values": qsr_relations_and_values}}
 
         o1 = [Object_State(name="o1", timestamp=0, x=1., y=1., width=5., length=8.),

--- a/qsr_lib/src/qsrlib/qsrlib.py
+++ b/qsr_lib/src/qsrlib/qsrlib.py
@@ -23,6 +23,7 @@ from qsrlib_qsrs.qsr_qtc_b_simplified import QSR_QTC_B_Simplified
 from qsrlib_qsrs.qsr_qtc_c_simplified import QSR_QTC_C_Simplified
 from qsrlib_qsrs.qsr_qtc_bc_simplified import QSR_QTC_BC_Simplified
 from qsrlib_qsrs.qsr_arg_relations_distance import QSR_Arg_Relations_Distance
+from qsrlib_qsrs.qsr_arg_prob_relations_distance import QSR_Arg_Prob_Relations_Distance
 from qsrlib_qsrs.qsr_moving_or_stationary import QSR_Moving_or_Stationary
 
 
@@ -96,6 +97,7 @@ class QSRlib(object):
                        "qtc_c_simplified": QSR_QTC_C_Simplified(),
                        "qtc_bc_simplified": QSR_QTC_BC_Simplified(),
                        "arg_relations_distance": QSR_Arg_Relations_Distance(),
+                       "arg_prob_relations_distance": QSR_Arg_Prob_Relations_Distance(),
                        "moving_or_stationary": QSR_Moving_or_Stationary()}
 
         if help:

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_prob_relations_distance.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_prob_relations_distance.py
@@ -21,18 +21,6 @@ class QSR_Arg_Prob_Relations_Distance(QSR_Arg_Relations_Distance):
         if config:
             self.set_from_config_file(config)
 
-    def custom_set_from_config_file(self, document):
-        try:
-            relations_and_values = document["arg_relations_distance"]["relations_and_values"]
-        except:
-            print("ERROR (qsr_arg_relations_distance.py/custom_set_from_config_file):"
-                  "'arg_relations_distance' or 'relations_and_values' not found in config file")
-            self.qsr_relations_and_values = None
-            self.all_possible_relations = None
-            self.all_possible_values = None
-            raise LookupError
-        self.set_qsr_relations_and_values(qsr_relations_and_values=relations_and_values)
-
     def custom_help(self):
         """Write your own help message function"""
         print("")

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_prob_relations_distance.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_prob_relations_distance.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Class for probabilistic distance QSR
+
+:Author: Christian Dondrup <cdondrup@lincoln.ac.uk>
+:Organization: University of Lincoln
+"""
+
+from __future__ import print_function, division
+import numpy as np
+from qsr_arg_relations_distance import QSR_Arg_Relations_Distance
+from qsrlib_io.world_qsr_trace import *
+
+
+class QSR_Arg_Prob_Relations_Distance(QSR_Arg_Relations_Distance):
+    def __init__(self, config=None):
+        super(QSR_Arg_Prob_Relations_Distance, self).__init__()
+        self.qsr_type = "arg_prob_relations_distance"
+        self.qsr_keys = "argprobd"
+        self.allowed_value_types = (tuple,list)
+        self.value_sort_key = lambda x: x[0] # Sort by mean
+        if config:
+            self.set_from_config_file(config)
+
+    def custom_set_from_config_file(self, document):
+        try:
+            relations_and_values = document["arg_relations_distance"]["relations_and_values"]
+        except:
+            print("ERROR (qsr_arg_relations_distance.py/custom_set_from_config_file):"
+                  "'arg_relations_distance' or 'relations_and_values' not found in config file")
+            self.qsr_relations_and_values = None
+            self.all_possible_relations = None
+            self.all_possible_values = None
+            raise LookupError
+        self.set_qsr_relations_and_values(qsr_relations_and_values=relations_and_values)
+
+    def custom_help(self):
+        """Write your own help message function"""
+        print("")
+
+    def custom_checks(self, input_data):
+        """Write your own custom checks on top of the default ones
+
+
+        :return: error code, error message (integer, string), use 10 and above for error code as 1-9 are reserved by system
+        """
+        return 0, ""
+
+    def custom_checks_for_qsrs_for(self, qsrs_for, error_found):
+        """qsrs_for must be tuples of two objects.
+
+        :param qsrs_for: list of strings and/or tuples for which QSRs will be computed
+        :param error_found: if an error was found in the qsrs_for that violates the QSR rules
+        :return: qsrs_for, error_found
+        """
+        for p in list(qsrs_for):
+            if (type(p) is not tuple) and (type(p) is not list) and (len(p) != 2):
+                qsrs_for.remove(p)
+                error_found = True
+        return qsrs_for, error_found
+
+    def __normpdf(self, x, mu, sigma):
+        u = (x-mu)/np.abs(sigma)
+        y = (1/(np.sqrt(2*np.pi)*np.abs(sigma)))*np.exp(-u*u/2)
+        return y
+
+    def _compute_qsr(self, objs):
+        d = np.sqrt(np.square(objs[0].x - objs[1].x) + np.square(objs[0].y - objs[1].y))
+        r = (None, 0.0)
+        for values, relation in zip(self.all_possible_values, self.all_possible_relations):
+            prob = self.__normpdf(d, mu=values[0], sigma=values[1])
+            r = (relation, prob) if prob > r[1] else r
+        return r[0] if r[0] else self.all_possible_relations[-1]

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_prob_relations_distance.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_prob_relations_distance.py
@@ -9,6 +9,7 @@ from __future__ import print_function, division
 import numpy as np
 from qsr_arg_relations_distance import QSR_Arg_Relations_Distance
 from qsrlib_io.world_qsr_trace import *
+from random import uniform
 
 
 class QSR_Arg_Prob_Relations_Distance(QSR_Arg_Relations_Distance):
@@ -49,12 +50,12 @@ class QSR_Arg_Prob_Relations_Distance(QSR_Arg_Relations_Distance):
     def __normpdf(self, x, mu, sigma):
         u = (x-mu)/np.abs(sigma)
         y = (1/(np.sqrt(2*np.pi)*np.abs(sigma)))*np.exp(-u*u/2)
-        return y
+        return np.around(y, decimals=3)
 
     def _compute_qsr(self, objs):
         d = np.sqrt(np.square(objs[0].x - objs[1].x) + np.square(objs[0].y - objs[1].y))
         r = (None, 0.0)
         for values, relation in zip(self.all_possible_values, self.all_possible_relations):
-            prob = self.__normpdf(d, mu=values[0], sigma=values[1])
+            prob = uniform(0.0, self.__normpdf(d, mu=values[0], sigma=values[1]))
             r = (relation, prob) if prob > r[1] else r
         return r[0] if r[0] else self.all_possible_relations[-1]

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_prob_relations_distance.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_prob_relations_distance.py
@@ -17,7 +17,7 @@ class QSR_Arg_Prob_Relations_Distance(QSR_Arg_Relations_Distance):
         self.qsr_type = "arg_prob_relations_distance"
         self.qsr_keys = "argprobd"
         self.allowed_value_types = (tuple,list)
-        self.value_sort_key = lambda x: x[0] # Sort by mean
+        self.value_sort_key = lambda x: x[1][0] # Sort by first element in value tuple, i.e. mean
         if config:
             self.set_from_config_file(config)
 

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_abstractclass.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_abstractclass.py
@@ -25,7 +25,6 @@ class QSR_Arg_Relations_Abstractclass(QSR_Abstractclass):
     def __populate_possible_relations_and_values(self):
         ret_relations = []
         ret_values = []
-
         sorted_by_v = sorted(self.qsr_relations_and_values.items(), key=self.value_sort_key)
         for i in sorted_by_v:
             ret_relations.append(i[0])

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_abstractclass.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_abstractclass.py
@@ -7,7 +7,6 @@
 
 from __future__ import print_function, division
 import abc
-import operator
 from qsrlib_qsrs.qsr_abstractclass import QSR_Abstractclass
 # from qsrlib_io.world_qsr_trace import *
 
@@ -20,11 +19,14 @@ class QSR_Arg_Relations_Abstractclass(QSR_Abstractclass):
         self.all_possible_relations = None
         self.all_possible_values = None
         self.qsr_keys = ""
+        self.allowed_value_types = None
+        self.value_sort_key = None
 
     def __populate_possible_relations_and_values(self):
         ret_relations = []
         ret_values = []
-        sorted_by_v = sorted(self.qsr_relations_and_values.items(), key=operator.itemgetter(1))
+
+        sorted_by_v = sorted(self.qsr_relations_and_values.items(), key=self.value_sort_key)
         for i in sorted_by_v:
             ret_relations.append(i[0])
             ret_values.append(i[1])
@@ -34,8 +36,11 @@ class QSR_Arg_Relations_Abstractclass(QSR_Abstractclass):
         if type(qsr_relations_and_values) is not dict:
             raise ValueError("qsr_relations_and_values must be a dict")
         for k, v in qsr_relations_and_values.items():
-            if (type(k) is not str) or ((type(v) is not float) and (type(v) is not int)):
-                raise ValueError("qsr_relations_and_values must be a dict of str:float|int")
+            if (type(k) is not str) or not isinstance(v, self.allowed_value_types):
+                try:
+                    raise ValueError("qsr_relations_and_values must be a dict of str:%s" % '|'.join(x.__name__ for x in self.allowed_value_types))
+                except TypeError:
+                    raise ValueError("qsr_relations_and_values must be a dict of str:%s" % self.allowed_value_types.__name__)
         return True
 
     def set_qsr_relations_and_values(self, qsr_relations_and_values):

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_distance.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_distance.py
@@ -7,6 +7,7 @@
 
 from __future__ import print_function, division
 import numpy as np
+import operator
 from qsr_arg_relations_abstractclass import QSR_Arg_Relations_Abstractclass
 from qsrlib_io.world_qsr_trace import *
 
@@ -15,6 +16,8 @@ class QSR_Arg_Relations_Distance(QSR_Arg_Relations_Abstractclass):
         super(QSR_Arg_Relations_Distance, self).__init__()
         self.qsr_type = "arg_relations_distance"
         self.qsr_keys = "argd"
+        self.allowed_value_types = (int,float)
+        self.value_sort_key = operator.itemgetter(1) # Sort by threshold
         if config:
             self.set_from_config_file(config)
 
@@ -75,7 +78,7 @@ class QSR_Arg_Relations_Distance(QSR_Arg_Relations_Abstractclass):
             if kwargs["qsr_relations_and_values"]:
                 print("Warning: This feature is deprecated, use dynamic_args on your request message instead")
                 self.set_qsr_relations_and_values(qsr_relations_and_values=kwargs["qsr_relations_and_values"])
-        except:
+        except KeyError:
             pass
         # optional direct set
         try:
@@ -87,7 +90,7 @@ class QSR_Arg_Relations_Distance(QSR_Arg_Relations_Abstractclass):
         try:
             if kwargs["dynamic_args"][self.qsr_keys]["qsr_relations_and_values"]:
                 self.set_qsr_relations_and_values(qsr_relations_and_values=kwargs["dynamic_args"][self.qsr_keys]["qsr_relations_and_values"])
-        except:
+        except KeyError:
             pass
         # print(self.qsr_relations_and_values)  # dbg
         if not self.qsr_relations_and_values:
@@ -110,14 +113,14 @@ class QSR_Arg_Relations_Distance(QSR_Arg_Relations_Abstractclass):
                     between = str(p[0]) + "," + str(p[1])
                     objs = (world_state.objects[p[0]], world_state.objects[p[1]])
                     qsr = QSR(timestamp=timestamp, between=between,
-                              qsr=self.handle_future(kwargs["future"], self.__compute_qsr(objs), self.qsr_keys))
+                              qsr=self.handle_future(kwargs["future"], self._compute_qsr(objs), self.qsr_keys))
                     ret.add_qsr(qsr, timestamp)
             else:
                 if include_missing_data:
                     ret.add_empty_world_qsr_state(timestamp)
         return ret
 
-    def __compute_qsr(self, objs):
+    def _compute_qsr(self, objs):
         if np.isnan(objs[0].z) or np.isnan(objs[1].z):
             d = np.sqrt(np.square(objs[0].x - objs[1].x) + np.square(objs[0].y - objs[1].y))
         else:

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_distance.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_relations_distance.py
@@ -85,7 +85,7 @@ class QSR_Arg_Relations_Distance(QSR_Arg_Relations_Abstractclass):
             if kwargs["dynamic_args"]["qsr_relations_and_values"]:
                 self.set_qsr_relations_and_values(qsr_relations_and_values=kwargs["dynamic_args"]["qsr_relations_and_values"])
                 print("Warning: This feature is deprecated, use dynamic_args with the namespace '%s' on your request message instead" % self.qsr_keys)
-        except:
+        except KeyError:
             pass
         try:
             if kwargs["dynamic_args"][self.qsr_keys]["qsr_relations_and_values"]:


### PR DESCRIPTION
This PR adds a simple probabilistic version of the arg_distance QSR. Distance regions are defined by the mean and standard deviation of a Gaussian. Depending on their overlap this results in a more or less ambiguous representation of distance that leaves room for variation of the generated robot behaviour, e.g. triggering circumvention of the human at different distances to allow for shaping of the initial values based on feedback. The config parameters look like this:

**_Edited to conform to latest state of lib:_**
```
dynamic_args = {"argprobd": {"qsr_relations_and_values": {
        "relation1": (mean1, sigma1),
        "relation2": (mean2, sigma2)
}}}
```

Changes made in this PR:

* Exposing the sorting key and the allowed value types in the abstract class so the inheriting classes can define them individually
* Using newly exposed key and allowed values fields in arg_distance
* Fixing a bug in arg_distance where the try except blocks for data retrieval would hide the exception raised by the check function of the abstract class
* Making compute_qsr function "protected" so it can be overridden (necessary because functions starting with two underscore `__` and ending with not more than one `_` are treated differently in python which makes overwriting them nasty)
* Create the actual arg_prob_distance QSR and added it to the library and ros example client.

Please merge #94 first so I can rebase this and make the necessary changes to conform to the new dynamic_args format.