### PR TITLE
Allows to call by QSR shortname now

### DIFF
--- a/qsr_lib/scripts/qsrlib_ros_server.py
+++ b/qsr_lib/scripts/qsrlib_ros_server.py
@@ -21,8 +21,8 @@ except:
 
 
 class QSRlib_ROS_Server(object):
-    def __init__(self, node_name="qsr_lib", active_qsrs=None):
-        self.qsrlib = QSRlib(active_qsrs)
+    def __init__(self, node_name="qsr_lib"):
+        self.qsrlib = QSRlib()
         self.node_name = node_name
         self.node = rospy.init_node(self.node_name)
         self.service_topic_names = {"request": self.node_name+"/request"}


### PR DESCRIPTION
- Allows to call by QSR shortname, by automatically registering the QSR shortnames (offers protection for ducplications)
- `QSRlib.__active_qsrs` removed
- `QSRlib.__const_qsrs_available` renamed to `__qsrs`
- Removed unused arguments
