### PR TITLE
Rcc abstract

### DIFF
--- a/qsr_lib/src/qsrlib_qsrs/qsr_rcc2_rectangle_bounding_boxes_2d.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_rcc2_rectangle_bounding_boxes_2d.py
@@ -1,27 +1,26 @@
 # -*- coding: utf-8 -*-
-"""Computes RCC2 relations: 'dc':disconnected, 'c': c
-
+"""RCC2, based upon RCC Abstract Class
 :Author: Yiannis Gatsoulis <y.gatsoulis@leeds.ac.uk>
+:Author: Peter Lightbody <plightbody@lincoln.ac.uk>
 :Organization: University of Leeds
+:Organization: University of Lincoln
 :Date: 10 September 2014
 :Version: 0.1
 :Status: Development
 :Copyright: STRANDS default
-:Notes: future extension to handle polygons, to do that use matplotlib.path.Path.contains_points
-        although might want to have a read on the following also...
-        http://matplotlib.1069221.n5.nabble.com/How-to-properly-use-path-Path-contains-point-td40718.html
 """
 
 from __future__ import print_function, division
-from qsrlib_qsrs.qsr_abstractclass import QSR_Abstractclass
+from qsrlib_qsrs.qsr_rcc_abstractclass import QSR_RCC_Abstractclass
 from qsrlib_io.world_qsr_trace import *
 
-
-class QSR_RCC2_Rectangle_Bounding_Boxes_2D(QSR_Abstractclass):
+class QSR_RCC2_Rectangle_Bounding_Boxes_2D(QSR_RCC_Abstractclass):
     """Make default QSRs and provide an example for others"""
     def __init__(self):
         self.qsr_type = "rcc2_rectangle_bounding_boxes_2d"  # must be the same that goes in the QSR_Lib.__const_qsrs_available
         self.qsr_keys = "rcc2"
+#         'dc'     bb1 is disconnected from bb2
+#         'c'      bb1 is connected to bb2
         self.all_possible_relations = ["dc", "c"]
 
     def custom_set_from_config_file(self, document):
@@ -33,83 +32,9 @@ class QSR_RCC2_Rectangle_Bounding_Boxes_2D(QSR_Abstractclass):
 
     def custom_checks(self, input_data):
         """Write your own custom checks on top of the default ones
-
-
         :return: error code, error message (integer, string), use 10 and above for error code as 1-9 are reserved by system
         """
         return 0, ""
 
-    def custom_checks_for_qsrs_for(self, qsrs_for, error_found):
-        """qsrs_for must be tuples of two objects.
-
-        :param qsrs_for: list of strings and/or tuples for which QSRs will be computed
-        :param error_found: if an error was found in the qsrs_for that violates the QSR rules
-        :return: qsrs_for, error_found
-        """
-        for p in list(qsrs_for):
-            if (type(p) is not tuple) and (type(p) is not list) and (len(p) != 2):
-                qsrs_for.remove(p)
-                error_found = True
-        return qsrs_for, error_found
-
-    def make(self, *args, **kwargs):
-        """Make the QSRs
-
-        :param args: not used at the moment
-        :param kwargs:
-                        - input_data: World_Trace
-        :return: World_QSR_Trace
-        """
-        input_data = kwargs["input_data"]
-        include_missing_data = kwargs["include_missing_data"]
-        ret = World_QSR_Trace(qsr_type=self.qsr_type)
-        try:
-            quantisation_factor = float(kwargs["dynamic_args"][self.qsr_keys]["quantisation_factor"])
-        except KeyError:
-            try:
-                quantisation_factor = float(kwargs["dynamic_args"]["quantisation_factor"])
-                print("Warning: This feature is deprecated, use dynamic_args with the namespace '%s' on your request message instead" % self.qsr_keys)
-            except (KeyError, TypeError):
-                quantisation_factor = 0.0
-        except TypeError:
-            quantisation_factor = 0.0
-
-        for t in input_data.get_sorted_timestamps():
-            world_state = input_data.trace[t]
-            timestamp = world_state.timestamp
-            if kwargs["qsrs_for"]:
-                qsrs_for, error_found = self.check_qsrs_for_data_exist(world_state.objects.keys(), kwargs["qsrs_for"])
-            else:
-                qsrs_for = self.__return_all_possible_combinations(world_state.objects.keys())
-            if qsrs_for:
-                for p in qsrs_for:
-                    between = str(p[0]) + "," + str(p[1])
-                    bb1 = world_state.objects[p[0]].return_bounding_box_2d()
-                    bb2 = world_state.objects[p[1]].return_bounding_box_2d()
-                    qsr = QSR(timestamp=timestamp, between=between,
-                              qsr=self.handle_future(kwargs["future"], self.__compute_qsr(bb1, bb2, quantisation_factor), self.qsr_keys))
-                    ret.add_qsr(qsr, timestamp)
-            else:
-                if include_missing_data:
-                    ret.add_empty_world_qsr_state(timestamp)
-        return ret
-
-    # custom functions follow
-    def __return_all_possible_combinations(self, objects_names):
-        if len(objects_names) < 2:
-            return []
-        ret = []
-        for i in objects_names:
-            for j in objects_names:
-                if i != j:
-                    ret.append((i, j))
-        return ret
-
-    def __compute_qsr(self, bb1, bb2, q=0.0):
-        """Return RCC2 relation
-
-        :param bb1: diagonal points coordinates of first bounding box (x1, y1, x2, y2)
-        :param bb2: diagonal points coordinates of second bounding box (x1, y1, x2, y2)
-        :return: an RCC2 relation from the following: 'dc':disconnected, 'c': connected
-        """
-        return "dc" if (bb1[0] > bb2[2]+q) or (bb1[2] < bb2[0]-q) or (bb1[1] > bb2[3]+q) or (bb1[3] < bb2[1]-q) else "c"
+    def convert_to_current_rcc(self, qsr):
+        return qsr if qsr =="dc" else "c"

--- a/qsr_lib/src/qsrlib_qsrs/qsr_rcc3_rectangle_bounding_boxes_2d.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_rcc3_rectangle_bounding_boxes_2d.py
@@ -1,27 +1,27 @@
 # -*- coding: utf-8 -*-
-"""Computes symmetrical RCC3 relations: 'dc':disconnected, 'po':partial overlap, 'o': occluded/part of
-
+"""RCC3, based upon RCC Abstract Class
 :Author: Yiannis Gatsoulis <y.gatsoulis@leeds.ac.uk>
+:Author: Peter Lightbody <plightbody@lincoln.ac.uk>
 :Organization: University of Leeds
+:Organization: University of Lincoln
 :Date: 10 September 2014
 :Version: 0.1
 :Status: Development
 :Copyright: STRANDS default
-:Notes: future extension to handle polygons, to do that use matplotlib.path.Path.contains_points
-        although might want to have a read on the following also...
-        http://matplotlib.1069221.n5.nabble.com/How-to-properly-use-path-Path-contains-point-td40718.html
 """
 
 from __future__ import print_function, division
-from qsrlib_qsrs.qsr_abstractclass import QSR_Abstractclass
+from qsrlib_qsrs.qsr_rcc_abstractclass import QSR_RCC_Abstractclass
 from qsrlib_io.world_qsr_trace import *
 
-
-class QSR_RCC3_Rectangle_Bounding_Boxes_2D(QSR_Abstractclass):
+class QSR_RCC3_Rectangle_Bounding_Boxes_2D(QSR_RCC_Abstractclass):
     """Make default QSRs and provide an example for others"""
     def __init__(self):
         self.qsr_type = "rcc3_rectangle_bounding_boxes_2d"  # must be the same that goes in the QSR_Lib.__const_qsrs_available
         self.qsr_keys = "rcc3"
+#         'dc'     bb1 is disconnected from bb2
+#         'po'     bb1 partially overlaps bb2
+#         'o'      bb1 is occluded or part of bb2
         self.all_possible_relations = ["dc", "po", "o"]
 
     def custom_set_from_config_file(self, document):
@@ -33,145 +33,10 @@ class QSR_RCC3_Rectangle_Bounding_Boxes_2D(QSR_Abstractclass):
 
     def custom_checks(self, input_data):
         """Write your own custom checks on top of the default ones
-
-
         :return: error code, error message (integer, string), use 10 and above for error code as 1-9 are reserved by system
         """
         return 0, ""
 
-    def custom_checks_for_qsrs_for(self, qsrs_for, error_found):
-        """qsrs_for must be tuples of two objects.
-
-        :param qsrs_for: list of strings and/or tuples for which QSRs will be computed
-        :param error_found: if an error was found in the qsrs_for that violates the QSR rules
-        :return: qsrs_for, error_found
-        """
-        for p in list(qsrs_for):
-            if (type(p) is not tuple) and (type(p) is not list) and (len(p) != 2):
-                qsrs_for.remove(p)
-                error_found = True
-        return qsrs_for, error_found
-
-    def make(self, *args, **kwargs):
-        """Make the QSRs
-
-        :param args: not used at the moment
-        :param kwargs:
-                        - input_data: World_Trace
-        :return: World_QSR_Trace
-        """
-        input_data = kwargs["input_data"]
-        include_missing_data = kwargs["include_missing_data"]
-        ret = World_QSR_Trace(qsr_type=self.qsr_type)
-        for t in input_data.get_sorted_timestamps():
-            world_state = input_data.trace[t]
-            timestamp = world_state.timestamp
-            if kwargs["qsrs_for"]:
-                qsrs_for, error_found = self.check_qsrs_for_data_exist(world_state.objects.keys(), kwargs["qsrs_for"])
-            else:
-                qsrs_for = self.__return_all_possible_combinations(world_state.objects.keys())
-            if qsrs_for:
-                for p in qsrs_for:
-                    between = str(p[0]) + "," + str(p[1])
-                    bb1 = world_state.objects[p[0]].return_bounding_box_2d()
-                    bb2 = world_state.objects[p[1]].return_bounding_box_2d()
-                    qsr = QSR(timestamp=timestamp, between=between,
-                              qsr=self.handle_future(kwargs["future"], self.__compute_qsr(bb1, bb2), self.qsr_keys))
-                    ret.add_qsr(qsr, timestamp)
-            else:
-                if include_missing_data:
-                    ret.add_empty_world_qsr_state(timestamp)
-        return ret
-
-    # custom functions follow
-    def __return_all_possible_combinations(self, objects_names):
-        if len(objects_names) < 2:
-            return []
-        ret = []
-        for i in objects_names:
-            for j in objects_names:
-                if i != j:
-                    ret.append((i, j))
-        return ret
-
-    def __compute_qsr(self, bb1, bb2):
-        """Return symmetrical RCC3 relation
-
-        :param bb1: diagonal points coordinates of first bounding box (x1, y1, x2, y2)
-        :param bb2: diagonal points coordinates of second bounding box (x1, y1, x2, y2)
-        :return: an RCC3 relation from the following: 'dc':disconnected, 'po':partial overlap, 'o': occluded/part of
-        """
-
-        bboxes_intercept_v, rabx, raxPrbx, raby, rayPrby = self.__bboxes_intercept(bb1, bb2)
-        if bboxes_intercept_v:
-            if rabx > 0.0 or raby > 0:
-                return "po"
-            else:
-                occluded_points = self.__count_occluded_points(bb1, bb2)
-                if occluded_points >= 4:
-                    return "o"
-                else:
-                    return "po"
-        else:
-            return "dc"
-
-
-    def __count_occluded_points(self, bb1, bb2):
-        occluded_points = 0
-        bb1_4corners = ((bb1[0], bb1[1]),
-                        (bb1[2], bb1[1]),
-                        (bb1[2], bb1[3]),
-                        (bb1[0], bb1[3]))
-        bb2_4corners = ((bb2[0], bb2[1]),
-                        (bb2[2], bb2[1]),
-                        (bb2[2], bb2[3]),
-                        (bb2[0], bb2[3]))
-
-        for p in bb1_4corners:
-            if self.__is_point_in_rectangle(p, bb2):
-                occluded_points += 1
-        for p in bb2_4corners:
-            if self.__is_point_in_rectangle(p, bb1):
-                occluded_points += 1
-
-        return occluded_points
-
-
-    def __is_point_in_rectangle(self, p, r, d=0.):
-        return p[0] >= r[0]-d and p[0] <= r[2]+d and p[1] >= r[0]-d and p[1] <= r[3]+d
-
-
-    def __bboxes_intercept(self, bb1, bb2):
-        """
-        https://rbrundritt.wordpress.com/2009/10/03/determining-if-two-bounding-boxes-overlap/
-
-        :param bb1: diagonal points coordinates of first bounding box (x1, y1, x2, y2)
-        :param bb2: diagonal points coordinates of second bounding box (x1, y1, x2, y2)
-        :return:
-        """
-
-        # First bounding box, top left corner, bottom right corner
-        ATLx = bb1[0]
-        ATLy = bb1[3]
-        ABRx = bb1[2]
-        ABRy = bb1[1]
-
-        # Second bounding box, top left corner, bottom right corner
-        BTLx = bb2[0]
-        BTLy = bb2[3]
-        BBRx = bb2[2]
-        BBRy = bb2[1]
-
-        rabx = abs(ATLx + ABRx - BTLx - BBRx)
-        raby = abs(ATLy + ABRy - BTLy - BBRy)
-
-        # rAx + rBx
-        raxPrbx = ABRx - ATLx + BBRx - BTLx
-
-        # rAy + rBy
-        rayPrby = ATLy - ABRy + BTLy - BBRy
-
-        if(rabx <= raxPrbx) and (raby <= rayPrby):
-            return True, rabx, raxPrbx, raby, rayPrby
-        else:
-            return False, rabx, raxPrbx, raby, rayPrby
+    def convert_to_current_rcc(self, qsr):
+        qsr = qsr.replace("ec", "po")
+        return qsr if qsr in self.all_possible_relations else self.all_possible_relations[-1]

--- a/qsr_lib/src/qsrlib_qsrs/qsr_rcc8_rectangle_bounding_boxes_2d.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_rcc8_rectangle_bounding_boxes_2d.py
@@ -122,28 +122,14 @@ class QSR_RCC8_Rectangle_Bounding_Boxes_2D(QSR_Abstractclass):
                  |            b|         |            d|
                  +-------------+         +-------------+
         """
-        
-        # Object 1 Top Left X
-        ax = bb1[0]
-        # Object 1 Top Left Y
-        ay = bb1[1]
-        # Object 2 Top Left X
-        cx = bb2[0]
-        # Object 2 Top Left X
-        cy = bb2[1]
-        # Object 1 Bottom Right X
-        bx = bb1[2]
-        # Object 1 Bottom Right Y
-        by = bb1[3]
-        # Object 2 Bottom Right X
-        dx = bb2[2]
-        # Object 2 Bottom Right Y
-        dy = bb2[3]
-    
+
         # CALCULATE EQ
         # Is object1 equal to object2
         if(bb1 == bb2):
             return "eq"
+
+        ax, ay, bx, by = bb1
+        cx, cy, dx, dy = bb2
     
         # Are objects disconnected?
         # Cond1. If A's left edge is to the right of the B's right edge, - then A is Totally to right Of B

--- a/qsr_lib/src/qsrlib_qsrs/qsr_rcc8_rectangle_bounding_boxes_2d.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_rcc8_rectangle_bounding_boxes_2d.py
@@ -1,22 +1,20 @@
 # -*- coding: utf-8 -*-
-"""RCC8, based upon RCC3
-
+"""RCC8, based upon RCC Abstract Class
 :Author: Peter Lightbody <plightbody@lincoln.ac.uk>
 :Author: Yiannis Gatsoulis <y.gatsoulis@leeds.ac.uk>
 :Organization: University of Lincoln
-:Date: 12 May 2015
+:Organization: University of Leeds
+:Date: 10 September 2014
 :Version: 0.1
 :Status: Development
 :Copyright: STRANDS default
-
 """
 
 from __future__ import print_function, division
-from qsrlib_qsrs.qsr_abstractclass import QSR_Abstractclass
+from qsrlib_qsrs.qsr_rcc_abstractclass import QSR_RCC_Abstractclass
 from qsrlib_io.world_qsr_trace import *
 
-
-class QSR_RCC8_Rectangle_Bounding_Boxes_2D(QSR_Abstractclass):
+class QSR_RCC8_Rectangle_Bounding_Boxes_2D(QSR_RCC_Abstractclass):
     """Make default QSRs and provide an example for others"""
     def __init__(self):
         self.qsr_type = "rcc8_rectangle_bounding_boxes_2d"  # must be the same that goes in the QSR_Lib.__const_qsrs_available
@@ -40,136 +38,9 @@ class QSR_RCC8_Rectangle_Bounding_Boxes_2D(QSR_Abstractclass):
 
     def custom_checks(self, input_data):
         """Write your own custom checks on top of the default ones
-
-
         :return: error code, error message (integer, string), use 10 and above for error code as 1-9 are reserved by system
         """
         return 0, ""
 
-    def custom_checks_for_qsrs_for(self, qsrs_for, error_found):
-        """qsrs_for must be tuples of two objects.
-
-        :param qsrs_for: list of strings and/or tuples for which QSRs will be computed
-        :param error_found: if an error was found in the qsrs_for that violates the QSR rules
-        :return: qsrs_for, error_found
-        """
-        for p in list(qsrs_for):
-            if (type(p) is not tuple) and (type(p) is not list) and (len(p) != 2):
-                qsrs_for.remove(p)
-                error_found = True
-        return qsrs_for, error_found
-
-    def make(self, *args, **kwargs):
-        """Make the QSRs
-
-        :param args: not used at the moment
-        :param kwargs:
-                        - input_data: World_Trace
-        :return: World_QSR_Trace
-        """
-        input_data = kwargs["input_data"]
-        include_missing_data = kwargs["include_missing_data"]
-        ret = World_QSR_Trace(qsr_type=self.qsr_type)
-        for t in input_data.get_sorted_timestamps():
-            world_state = input_data.trace[t]
-            timestamp = world_state.timestamp
-            if kwargs["qsrs_for"]:
-                qsrs_for, error_found = self.check_qsrs_for_data_exist(world_state.objects.keys(), kwargs["qsrs_for"])
-            else:
-                qsrs_for = self.__return_all_possible_combinations(world_state.objects.keys())
-            if qsrs_for:
-                for p in qsrs_for:
-                    between = str(p[0]) + "," + str(p[1])
-                    bb1 = world_state.objects[p[0]].return_bounding_box_2d()
-                    bb2 = world_state.objects[p[1]].return_bounding_box_2d()
-                    qsr = QSR(timestamp=timestamp, between=between,
-                              qsr=self.handle_future(kwargs["future"], self.__compute_qsr(bb1, bb2), self.qsr_keys))
-                    ret.add_qsr(qsr, timestamp)
-            else:
-                if include_missing_data:
-                    ret.add_empty_world_qsr_state(timestamp)
-        return ret
-
-    # custom functions follow
-    def __return_all_possible_combinations(self, objects_names):
-        if len(objects_names) < 2:
-            return []
-        ret = []
-        for i in objects_names:
-            for j in objects_names:
-                if i != j:
-                    ret.append((i, j))
-        return ret
-
-    def __compute_qsr(self, bb1, bb2):
-        """Return symmetrical RCC8 relation
-            :param bb1: diagonal points coordinates of first bounding box (x1, y1, x2, y2)
-            :param bb2: diagonal points coordinates of second bounding box (x1, y1, x2, y2)
-            :return: an RCC8 relation from the following:
-                'dc'     bb1 is disconnected from bb2
-                'ec'     bb1 is externally connected with bb2
-                'po'     bb1 partially overlaps bb2
-                'eq'     bb1 equals bb2
-                'tpp'    bb1 is a tangential proper part of bb2
-                'ntpp'   bb1 is a non-tangential proper part of bb2
-                'tppi'   bb2 is a tangential proper part of bb1
-                'ntppi'  bb2 is a non-tangential proper part of bb1
-                 +-------------+         +-------------+
-                 |a            |         |c            |
-                 |             |         |             |
-                 |     bb1     |         |     bb2     |
-                 |             |         |             |
-                 |            b|         |            d|
-                 +-------------+         +-------------+
-        """
-
-        # CALCULATE EQ
-        # Is object1 equal to object2
-        if(bb1 == bb2):
-            return "eq"
-
-        ax, ay, bx, by = bb1
-        cx, cy, dx, dy = bb2
-    
-        # Are objects disconnected?
-        # Cond1. If A's left edge is to the right of the B's right edge, - then A is Totally to right Of B
-        # Cond2. If A's right edge is to the left of the B's left edge, - then A is Totally to left Of B
-        # Cond3. If A's top edge is below B's bottom edge, - then A is Totally below B
-        # Cond4. If A's bottom edge is above B's top edge, - then A is Totally above B
-        
-        #    Cond1        Cond2        Cond3        Cond4
-        if (ax > dx) or (bx < cx) or (ay > dy) or (by < cy):
-            return "dc"
-    
-        # Is one object inside the other
-        BinsideA = (ax <= cx) and (ay <= cy) and (bx >= dx) and (by >= dy)
-        AinsideB = (ax >= cx) and (ay >= cy) and (bx <= dx) and (by <= dy)
-    
-        # Do objects share an X or Y (but are not necessarily touching)
-        sameX = (ax == cx or ax == dx or bx == cx or bx == dx)
-        sameY = (ay == cy or ay == dy or by == cy or by == dy)
-    
-        if AinsideB and (sameX or sameY):
-            return "tpp"
-    
-        if BinsideA and (sameX or sameY):
-            return "tppi"
-    
-        if AinsideB:
-            return "ntpp"
-    
-        if BinsideA:
-            return "ntppi"
-    
-        # Are objects touching?
-        # Cond1. If A's left edge is equal to B's right edge, - then A is to the right of B and touching
-        # Cond2. If A's right edge is qual to B's left edge, - then A is to the left of B and touching
-        # Cond3. If A's top edge equal to B's bottom edge, - then A is below B and touching
-        # Cond4. If A's bottom edge equal to B's top edge, - then A is above B and touching
-    
-        #    Cond1        Cond2        Cond3        Cond4
-        if (ax == dx) or (bx == cx) or (ay == dy) or (by == cy):
-            return "ec"
-    
-        # If none of the other conditions are met, the objects must be parially overlapping
-        return "po"
+    def convert_to_current_rcc(self, qsr):
+        return qsr

--- a/qsr_lib/src/qsrlib_qsrs/qsr_rcc_abstractclass.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_rcc_abstractclass.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+"""RCC Abstract Class - A base class for all other RCC implementation
+
+:Author: Peter Lightbody <plightbody@lincoln.ac.uk>
+:Organization: University of Lincoln
+:Date: 10 Aug 2015
+:Version: 0.1
+:Status: Development
+:Copyright: STRANDS default
+
+:Notes: future extension to handle polygons, to do that use matplotlib.path.Path.contains_points
+        although might want to have a read on the following also...
+        http://matplotlib.1069221.n5.nabble.com/How-to-properly-use-path-Path-contains-point-td40718.html
+
+"""
+from abc import abstractmethod, ABCMeta
+from qsrlib_qsrs.qsr_abstractclass import QSR_Abstractclass
+from qsrlib_io.world_qsr_trace import *
+from exceptions import Exception, AttributeError
+import numpy as np
+
+class QSR_RCC_Abstractclass(QSR_Abstractclass):
+    """Abstract class for the QSR makers"""
+    __metaclass__ = ABCMeta
+
+    def __init__(self):
+        self.qsr_type = ""
+        self.qsr_keys = ""
+        self.all_possible_relations = []
+
+    def custom_checks_for_qsrs_for(self, qsrs_for, error_found):
+        """qsrs_for must be tuples of two objects.
+
+        :param qsrs_for: list of strings and/or tuples for which QSRs will be computed
+        :param error_found: if an error was found in the qsrs_for that violates the QSR rules
+        :return: qsrs_for, error_found
+        """
+        for p in list(qsrs_for):
+            if (type(p) is not tuple) and (type(p) is not list) and (len(p) != 2):
+                qsrs_for.remove(p)
+                error_found = True
+        return qsrs_for, error_found
+
+    def make(self, *args, **kwargs):
+        """Make the QSRs
+
+        :param args: not used at the moment
+        :param kwargs:
+                        - input_data: World_Trace
+        :return: World_QSR_Trace
+        """
+        input_data = kwargs["input_data"]
+        include_missing_data = kwargs["include_missing_data"]
+        ret = World_QSR_Trace(qsr_type=self.qsr_type)
+        for t in input_data.get_sorted_timestamps():
+            world_state = input_data.trace[t]
+            timestamp = world_state.timestamp
+            if kwargs["qsrs_for"]:
+                qsrs_for, error_found = self.check_qsrs_for_data_exist(world_state.objects.keys(), kwargs["qsrs_for"])
+            else:
+                qsrs_for = self.__return_all_possible_combinations(world_state.objects.keys())
+            if qsrs_for:
+                for p in qsrs_for:
+                    between = str(p[0]) + "," + str(p[1])
+                    bb1 = world_state.objects[p[0]].return_bounding_box_2d()
+                    bb2 = world_state.objects[p[1]].return_bounding_box_2d()
+                    qsr = QSR(timestamp=timestamp, between=between,
+                              qsr=self.handle_future(kwargs["future"], self.convert_to_current_rcc(self.__compute_qsr(bb1, bb2)), self.qsr_keys))
+                    ret.add_qsr(qsr, timestamp)
+            else:
+                if include_missing_data:
+                    ret.add_empty_world_qsr_state(timestamp)
+        return ret
+
+    def __return_all_possible_combinations(self, objects_names):
+        if len(objects_names) < 2:
+            return []
+        ret = []
+        for i in objects_names:
+            for j in objects_names:
+                if i != j:
+                    ret.append((i, j))
+        return ret
+
+    def __compute_qsr(self, bb1, bb2, q=0.0):
+        """Return symmetrical RCC8 relation
+            :param bb1: diagonal points coordinates of first bounding box (x1, y1, x2, y2)
+            :param bb2: diagonal points coordinates of second bounding box (x1, y1, x2, y2)
+            :param q: quantisation factor
+            :return: an RCC8 relation from the following:
+                'dc'     bb1 is disconnected from bb2
+                'ec'     bb1 is externally connected with bb2
+                'po'     bb1 partially overlaps bb2
+                'eq'     bb1 equals bb2
+                'tpp'    bb1 is a tangential proper part of bb2
+                'ntpp'   bb1 is a non-tangential proper part of bb2
+                'tppi'   bb2 is a tangential proper part of bb1
+                'ntppi'  bb2 is a non-tangential proper part of bb1
+                 +-------------+         +-------------+
+                 |a            |         |c            |
+                 |             |         |             |
+                 |     bb1     |         |     bb2     |
+                 |             |         |             |
+                 |            b|         |            d|
+                 +-------------+         +-------------+
+        """
+
+        # CALCULATE EQ
+        # Is object1 equal to object2
+        if(bb1 == bb2):
+            return "eq"
+
+        ax, ay, bx, by = bb1
+        cx, cy, dx, dy = bb2
+    
+        # Are objects disconnected?
+        # Cond1. If A's left edge is to the right of the B's right edge, - then A is Totally to right Of B
+        # Cond2. If A's right edge is to the left of the B's left edge, - then A is Totally to left Of B
+        # Cond3. If A's top edge is below B's bottom edge, - then A is Totally below B
+        # Cond4. If A's bottom edge is above B's top edge, - then A is Totally above B
+        
+        #    Cond1           Cond2          Cond3         Cond4
+        if (ax > dx+q) or (bx < cx-q) or (ay > dy+q) or (by < cy-q):
+            return "dc"
+    
+        # Is one object inside the other
+        BinsideA = (ax <= cx) and (ay <= cy) and (bx >= dx) and (by >= dy)
+        AinsideB = (ax >= cx) and (ay >= cy) and (bx <= dx) and (by <= dy)
+    
+        # Do objects share an X or Y (but are not necessarily touching)
+        sameX = (ax == cx or ax == dx or bx == cx or bx == dx)
+        sameY = (ay == cy or ay == dy or by == cy or by == dy)
+    
+        if AinsideB and (sameX or sameY):
+            return "tpp"
+    
+        if BinsideA and (sameX or sameY):
+            return "tppi"
+    
+        if AinsideB:
+            return "ntpp"
+    
+        if BinsideA:
+            return "ntppi"
+    
+        # Are objects touching?
+        # Cond1. If A's left edge is equal to B's right edge, - then A is to the right of B and touching
+        # Cond2. If A's right edge is qual to B's left edge, - then A is to the left of B and touching
+        # Cond3. If A's top edge equal to B's bottom edge, - then A is below B and touching
+        # Cond4. If A's bottom edge equal to B's top edge, - then A is above B and touching
+    
+        #    Cond1        Cond2        Cond3        Cond4
+        if (ax == dx) or (bx == cx) or (ay == dy) or (by == cy):
+            return "ec"
+    
+        # If none of the other conditions are met, the objects must be parially overlapping
+        return "po"
+
+
+    @abstractmethod
+    def convert_to_current_rcc(self, qsr):
+        """Overwrite this function to filter and return only the relations
+        coresponding to the particular RCC version you are using.
+        
+        Example for RCC2: return qsr if qsr =="dc" else "c"
+
+        :param qtc: The RCC8 relation between two objects
+        :return: The part of the tuple you would to have as a result
+        """
+        raise NotImplementedError("Filter RCC results using convert_to_current_rcc function")


### PR DESCRIPTION
I've abstracted all of the RCC implementations as it saves making small differences to multiple files. To extend it further, (e.g. RCC5) you can just base it off the abstract class and they filter the results. I got the same output as before during my tests and also checked the performance compared to the individual classes as shown below:

|     Method    |    per 1000 requests (seconds)  |    Average request  (seconds)  |
|:-------------:|:-------------:|:----------------:|
| RCC2 Original | 1.82747459412 | 0.00182747459412 |
| RCC3 Original | 1.82822918892 | 0.00182822918892 |
| RCC8 Original | 2.09537005424 | 0.00209537005424 |
| RCC2 Abstract | 1.79990291595 | 0.00179990291595 |
| RCC3 Abstract | 1.79684948921 | 0.00179684948921 |
| RCC8 Abstract |  2.1147005558 |  0.0021147005558 |

RCC3 and RCC2 are slightly faster as their conditions are checked first, RCC8 is slightly slower, which makes sense as the exact same method is being called, but abstracting it does add a slight bit of overhead.

@yianni would you mind testing this?