### PR TITLE
[qsr_lib] QTC performance enhancements

### DIFF
--- a/qsr_lib/src/qsrlib_qsrs/qsr_qtc_bc_simplified.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_qtc_bc_simplified.py
@@ -54,9 +54,21 @@ class QSR_QTC_BC_Simplified(QSR_QTC_Simplified_Abstractclass):
         else:
             qsrs_for = self._return_all_possible_combinations(sorted(input_data.trace[timestamps[0]].objects.keys()))
 
+        combinations = {}
         if qsrs_for:
             for p in qsrs_for:
                 between = str(p[0]) + "," + str(p[1])
+                # If the opposit combination of objects has been calculated before,
+                # Just flip the numbers around and republish.
+                if str(p[1]) + "," + str(p[0]) in combinations.keys():
+                    for idx, qtc in enumerate(combinations[str(p[1]) + "," + str(p[0])]):
+                        qsr = QSR(
+                            timestamp=idx+1,
+                            between=between,
+                            qsr=self.qtc_to_output_format((qtc[[1,0,3,2]]), kwargs["future"])
+                        )
+                        ret.add_qsr(qsr, idx+1)
+                    continue
                 o1_name = p[0]
                 o2_name = p[1]
                 quantisation_factor = parameters["quantisation_factor"]
@@ -134,6 +146,7 @@ class QSR_QTC_BC_Simplified(QSR_QTC_Simplified_Abstractclass):
                         qsr=self.qtc_to_output_format((qtc), kwargs["future"])
                     )
                     ret.add_qsr(qsr, idx+1)
+                combinations[between] = qtc_sequence
 
         if no_collapse and not validate:
             ret = self._rectify_timestamps(input_data, ret)

--- a/qsr_lib/src/qsrlib_qsrs/qsr_qtc_bc_simplified.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_qtc_bc_simplified.py
@@ -69,6 +69,9 @@ class QSR_QTC_BC_Simplified(QSR_QTC_Simplified_Abstractclass):
         except:
             pass
 
+        if not type(no_collapse) is bool or not type(validate) is bool:
+            raise Exception("'no_collapse' and 'validate' have to be boolean values.")
+
         if qsrs_for:
             for p in qsrs_for:
                 between = str(p[0]) + "," + str(p[1])
@@ -141,9 +144,6 @@ class QSR_QTC_BC_Simplified(QSR_QTC_Simplified_Abstractclass):
 
                     except KeyError:
                         ret.add_empty_world_qsr_state(timestamp)
-
-                if not type(no_collapse) is bool or not type(validate) is bool:
-                    raise Exception("'no_collapse' and 'validate' have to be boolean values.")
 
                 qtc_sequence = self._create_bc_chain(qtc_sequence, distances, distance_threshold)
                 if not no_collapse:

--- a/qsr_lib/src/qsrlib_qsrs/qsr_qtc_simplified_abstractclass.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_qtc_simplified_abstractclass.py
@@ -406,9 +406,25 @@ class QSR_QTC_Simplified_Abstractclass(QSR_Abstractclass):
 
         parameters = self._get_parameters(parameters, **kwargs)
 
+        combinations = {}
         if qsrs_for:
             for p in qsrs_for:
                 between = str(p[0]) + "," + str(p[1])
+                # If the opposit combination of objects has been calculated before,
+                # Just flip the numbers around and republish.
+                if str(p[1]) + "," + str(p[0]) in combinations.keys():
+                    for idx, qtc in enumerate(combinations[str(p[1]) + "," + str(p[0])]):
+                        try:
+                            new = qtc[[1,0,3,2]]
+                        except IndexError:
+                            new = qtc[[1,0]] # QTCb
+                        qsr = QSR(
+                            timestamp=idx+1,
+                            between=between,
+                            qsr=self.qtc_to_output_format(new, kwargs["future"])
+                        )
+                        ret.add_qsr(qsr, idx+1)
+                    continue
                 o1_name = p[0]
                 o2_name = p[1]
                 quantisation_factor = parameters["quantisation_factor"]
@@ -468,6 +484,7 @@ class QSR_QTC_Simplified_Abstractclass(QSR_Abstractclass):
                         qsr=self.qtc_to_output_format((qtc), kwargs["future"])
                     )
                     ret.add_qsr(qsr, idx+1)
+                combinations[between] = qtc_sequence
 
         if no_collapse and not validate:
             ret = self._rectify_timestamps(input_data, ret)

--- a/qsr_lib/src/qsrlib_qsrs/qsr_qtc_simplified_abstractclass.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_qtc_simplified_abstractclass.py
@@ -21,6 +21,7 @@ class QSR_QTC_Simplified_Abstractclass(QSR_Abstractclass):
     __metaclass__ = ABCMeta
 
     __qsr_keys = "qtcs"
+    __no_state__ = 9.
 
     def __init__(self):
         self._unique_id = ""
@@ -130,14 +131,11 @@ class QSR_QTC_Simplified_Abstractclass(QSR_Abstractclass):
         if self.qtc_type == "b":
             qtc = qtc[:,0:2].copy()
 
-        col_qtc = np.array([qtc[0,:].copy()])
-        j = 0
-        for i in xrange(1, qtc.shape[0]):
-            if not self._nan_equal(col_qtc[j,:], qtc[i,:]):
-                col_qtc = np.append(col_qtc, [qtc[i,:]], axis=0)
-                j += 1
-
-        return col_qtc
+        # The nan handling is a bit hacky but fast and easy
+        if qtc.dtype == np.float64: qtc[np.isnan(qtc)]=self.__no_state__
+        qtc = qtc[np.concatenate(([True],np.any(qtc[1:]!=qtc[:-1],axis=1)))]
+        if qtc.dtype == np.float64: qtc[qtc==self.__no_state__] = np.nan
+        return qtc
 
     def _nan_equal(self, a, b):
         """Uses assert equal to compare if two arrays containing nan values

--- a/qsr_lib/src/qsrlib_qsrs/qsr_qtc_simplified_abstractclass.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_qtc_simplified_abstractclass.py
@@ -421,6 +421,8 @@ class QSR_QTC_Simplified_Abstractclass(QSR_Abstractclass):
         except:
             pass
 
+        if not type(no_collapse) is bool or not type(validate) is bool:
+            raise Exception("'no_collapse' and 'validate' have to be boolean values.")
 
         if qsrs_for:
             for p in qsrs_for:
@@ -477,9 +479,6 @@ class QSR_QTC_Simplified_Abstractclass(QSR_Abstractclass):
 
                     except KeyError:
                         ret.add_empty_world_qsr_state(timestamp)
-
-                if not type(no_collapse) is bool or not type(validate) is bool:
-                    raise Exception("'no_collapse' and 'validate' have to be boolean values.")
 
                 if not no_collapse:
                     qtc_sequence = self._collapse_similar_states(qtc_sequence)


### PR DESCRIPTION
**Minor:** The collapsing of chains has been vectorised. Saves 0.02~0.04 seconds on the test sample with 364 measurements.
**Major:** Creating a lookup table of previously calculated QTC state chains for object pair combinations. If an object pair is requested, we first check if the inverse pair has been calculated before. If so, just flip the names and numbers around and add the new result to the output. This almost halfs the computation time if no `qsrs_for` are specified. Of course, if `qsrs_for` does not contain "duplicates", this has no effect.