### PR TITLE
Adding new QSR qtcbcs_argprobd - Version 0.2

### DIFF
--- a/qsr_lib/scripts/example_extended.py
+++ b/qsr_lib/scripts/example_extended.py
@@ -13,8 +13,8 @@ import csv
 
 
 if __name__ == "__main__":
-    options = ["rcc2", "rcc3", "rcc8", "coneDir", "qtcbs", "qtccs", "qtcbcs", "argd", "argprobd", "mos", "multiple"]
-    multiple = options[:]; multiple.remove("multiple"); multiple.remove("argd"); multiple.remove("argprobd")
+    options = ["rcc2", "rcc3", "rcc8", "coneDir", "qtcbs", "qtccs", "qtcbcs", "qtcbcs_argprobd", "argd", "argprobd", "mos", "multiple"]
+    multiple = options[:]; multiple.remove("multiple"); multiple.remove("argd"); multiple.remove("argprobd"); multiple.remove("qtcbcs_argprobd")
 
     parser = argparse.ArgumentParser()
     parser.add_argument("qsr", help="choose qsr: %s" % options, type=str)
@@ -22,7 +22,7 @@ if __name__ == "__main__":
     parser.add_argument("--validate", help="validate state chain. Only QTC", action="store_true")
     parser.add_argument("--quantisation_factor", help="quantisation factor for 0-states in qtc, or 's'-states in mos", type=float)
     parser.add_argument("--no_collapse", help="does not collapse similar adjacent states. Only QTC", action="store_true")
-    parser.add_argument("--distance_threshold", help="distance threshold for qtcb <-> qtcc transition. Only QTCBC", type=float)
+    parser.add_argument("--distance_threshold", help="distance threshold for qtcb <-> qtcc transition. Only QTCBC. Float for qtcbcs or string for qtcbcs_argprobd.")
     parser.add_argument("-c", "--config", help="config file", type=str)
     parser.add_argument("--ros", action="store_true", default=False, help="Use ROS eco-system")
     args = parser.parse_args()
@@ -224,13 +224,26 @@ if __name__ == "__main__":
             world.add_object_state_series(o1)
             world.add_object_state_series(o2)
 
-    elif which_qsr == "qtcbcs":
+    elif which_qsr in ("qtcbcs", "qtcbcs_argprobd"):
         dynamic_args = {which_qsr: {
             "quantisation_factor": args.quantisation_factor,
             "distance_threshold": args.distance_threshold,
             "validate": args.validate,
             "no_collapse": args.no_collapse
-        }}
+        }} if which_qsr == "qtcbcs" else \
+            {which_qsr: {
+                "quantisation_factor": args.quantisation_factor,
+                "distance_threshold": args.distance_threshold,
+                "validate": args.validate,
+                "no_collapse": args.no_collapse,
+                "qsr_relations_and_values": {
+                    "int": (  (.46-.0)/2  +.0,    (.46-.0)/4),
+                    "per": ((1.22-.46)/2 +.46,  (1.22-.46)/4),
+                    "soc": ((3.7-1.22)/2+1.22,  (3.7-1.22)/4),
+                    "pub": ((6.0-3.7)/2  +3.7,   (6.0-3.7)/4),
+                    "und": ((10.0-6.0)/2 +6.0,  (10.0-6.0)/4)
+                }
+            }}
 
         if args.input:
             ob = []

--- a/qsr_lib/src/qsrlib_qsrs/__init__.py
+++ b/qsr_lib/src/qsrlib_qsrs/__init__.py
@@ -5,6 +5,7 @@ from qsr_cone_direction_bounding_boxes_centroid_2d import QSR_Cone_Direction_Bou
 from qsr_qtc_b_simplified import QSR_QTC_B_Simplified
 from qsr_qtc_c_simplified import QSR_QTC_C_Simplified
 from qsr_qtc_bc_simplified import QSR_QTC_BC_Simplified
+from qsr_qtc_bc_simplified_arg_prob_distance import QSR_QTC_BC_Simplified_Arg_Prob_Distance
 from qsr_arg_relations_distance import QSR_Arg_Relations_Distance
 from qsr_arg_prob_relations_distance import QSR_Arg_Prob_Relations_Distance
 from qsr_moving_or_stationary import QSR_Moving_or_Stationary
@@ -18,6 +19,7 @@ qsrs_registry = (QSR_RCC2_Rectangle_Bounding_Boxes_2D,
                  QSR_QTC_B_Simplified,
                  QSR_QTC_C_Simplified,
                  QSR_QTC_BC_Simplified,
+                 QSR_QTC_BC_Simplified_Arg_Prob_Distance,
                  QSR_Arg_Relations_Distance,
                  QSR_Arg_Prob_Relations_Distance,
                  QSR_Moving_or_Stationary,

--- a/qsr_lib/src/qsrlib_qsrs/qsr_arg_prob_relations_distance.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_arg_prob_relations_distance.py
@@ -20,7 +20,7 @@ class QSR_Arg_Prob_Relations_Distance(QSR_Arg_Relations_Distance):
         if config:
             self.set_from_config_file(config)
 
-    def __normpdf(self, x, mu, sigma):
+    def _normpdf(self, x, mu, sigma):
         u = (x-mu)/np.abs(sigma)
         y = (1/(np.sqrt(2*np.pi)*np.abs(sigma)))*np.exp(-u*u/2)
         return np.around(y, decimals=3)
@@ -29,6 +29,6 @@ class QSR_Arg_Prob_Relations_Distance(QSR_Arg_Relations_Distance):
         d = np.sqrt(np.square(data1.x - data2.x) + np.square(data1.y - data2.y))
         r = (None, 0.0)
         for values, relation in zip(self.all_possible_values, self.all_possible_relations):
-            prob = uniform(0.0, self.__normpdf(d, mu=values[0], sigma=values[1]))
+            prob = uniform(0.0, self._normpdf(d, mu=values[0], sigma=values[1]))
             r = (relation, prob) if prob > r[1] else r
         return r[0] if r[0] else self.all_possible_relations[-1]

--- a/qsr_lib/src/qsrlib_qsrs/qsr_qtc_bc_simplified_arg_prob_distance.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_qtc_bc_simplified_arg_prob_distance.py
@@ -13,21 +13,35 @@
 """
 
 from __future__ import division
-from qsrlib_qsrs.qsr_qtc_simplified_abstractclass import QSR_QTC_Simplified_Abstractclass
+from qsrlib_qsrs.qsr_qtc_bc_simplified import QSR_QTC_BC_Simplified
+from qsrlib_qsrs.qsr_arg_prob_relations_distance import QSR_Arg_Prob_Relations_Distance
 import numpy as np
 from qsrlib_io.world_qsr_trace import *
+from random import uniform
 
 
-class QSR_QTC_BC_Simplified(QSR_QTC_Simplified_Abstractclass):
+# QSR_QTC_BC_Simplified has to be first so it finds the correct functions implementations from QTC
+class QSR_QTC_BC_Simplified_Arg_Prob_Distance(QSR_QTC_BC_Simplified, QSR_Arg_Prob_Relations_Distance):
     """Make default QSRs and provide an example for others"""
     def __init__(self):
-        super(QSR_QTC_BC_Simplified, self).__init__()
-        self._unique_id = "qtcbcs"
+        super(QSR_QTC_BC_Simplified_Arg_Prob_Distance, self).__init__()
         self.qtc_type = "bc"
         self.all_possible_relations = self.return_all_possible_state_combinations()[0]
+        self._unique_id = "qtcbcs_argprobd"
+        self.prev_dist = ''
+        self._qsr_params_defaults = {
+            "distance_threshold": 'und',
+            "quantisation_factor": 0.0,
+            "validate": True,
+            "no_collapse": False,
+            "qsr_relations_and_values": {}
+        }
+        self.allowed_value_types = (tuple, list)
+        self.value_sort_key = lambda x: x[1][0] # Sort by first element in value tuple, i.e. mean
 
     def make_world_qsr_trace(self, world_trace, timestamps, qsr_params, req_params, **kwargs):
         ret = World_QSR_Trace(qsr_type=self._unique_id)
+        self.set_qsr_relations_and_values(qsr_params["qsr_relations_and_values"])
         qtc_sequence = {}
         for t, tp in zip(timestamps[1:], timestamps):
             world_state_now = world_trace.trace[t]
@@ -52,12 +66,7 @@ class QSR_QTC_BC_Simplified(QSR_QTC_Simplified_Abstractclass):
                     l,
                     qsr_params["quantisation_factor"]
                 )
-                distance = self._get_euclidean_distance(
-                    (world_state_now.objects[o1_name].x,
-                         world_state_now.objects[o1_name].y),
-                    (world_state_now.objects[o2_name].x,
-                         world_state_now.objects[o2_name].y)
-                )
+                distance = self._compute_distance((world_state_now.objects[o1_name], world_state_now.objects[o2_name]), qtc)
 
                 try:
                     qtc_sequence[between]["qtc"] = np.append(
@@ -74,10 +83,6 @@ class QSR_QTC_BC_Simplified(QSR_QTC_Simplified_Abstractclass):
                         "distances": np.array([distance])
                     }
 
-        try: # Check if d thresh is a float
-            float(qsr_params["distance_threshold"])
-        except ValueError:
-            raise Exception("%s only accepts floats for distance_threshold" % self._unique_id)
         for between, qtcbc in qtc_sequence.items():
             qtcbc["qtc"] = self._create_bc_chain(qtcbc["qtc"], qtcbc["distances"], qsr_params["distance_threshold"])
             if not qsr_params["no_collapse"]:
@@ -99,30 +104,37 @@ class QSR_QTC_BC_Simplified(QSR_QTC_Simplified_Abstractclass):
         if len(qtc.shape) == 1:
             qtc = [qtc]
         for dist, state in zip(distances, qtc):
-            if dist > distance_threshold:
+            if self.all_possible_relations.index(dist) > self.all_possible_relations.index(distance_threshold):
                 ret = np.append(ret, np.append(state[0:2],[np.nan,np.nan]), axis=0)
             else:
                 ret = np.append(ret, state, axis=0)
+
         return ret.reshape(-1,4)
 
-    def qtc_to_output_format(self, qtc):
-        """Overwrite this for the different QTC veriants to select only the parts
-        from the QTCC tuple that you would like to return.
-        Example for QTCB: return qtc[0:2]
+    def _compute_distance(self, objs, qtc):
+        # Same computation as in argprobd but taking the QTC state into account.
+        # E.g. if the velocities point towards each other, the distance cannot increase
+        if self.prev_dist != '':
+            if np.all(qtc[:2] == [0,0]): # No change in distance possible
+                return self.prev_dist
+            elif np.sum(qtc[:2]) < 0: # [-0,--,0-] coming closer, ruling out distances further away than the last
+                start_idx = 0
+                end_idx = self.all_possible_relations.index(self.prev_dist)+1
+            elif np.sum(qtc[:2]) > 0: # [+0,++,0+] moving away, ruling out distances closer than the last
+                start_idx = self.all_possible_relations.index(self.prev_dist)
+                end_idx = len(self.all_possible_relations)
+            else: # [+-,-+] Undefined states in simplified QTC, all is fair game
+                start_idx = 0
+                end_idx = len(self.all_possible_relations)
+        else:
+            start_idx = 0
+            end_idx = len(self.all_possible_relations)
 
-        :param qtc: The full QTCC tuple [q1,q2,q4,q5]
+        d = np.sqrt(np.square(objs[0].x - objs[1].x) + np.square(objs[0].y - objs[1].y))
+        r = (None, 0.0)
 
-        :return: "q1,q2,q4,q5" or {"qtcbcs": "q1,q2,q4,q5"} if future is True
-        """
-        s = self.create_qtc_string(qtc) if not np.isnan(qtc[2]) else self.create_qtc_string(qtc[0:2])
-        return self._format_qsr(s)
-
-    def _get_euclidean_distance(self, p, q):
-        """Calculate the Euclidean distance between points p and q
-
-        :param p: tuple of x,y coordinates
-        :param q: tuple of x,y coordinates
-
-        :return: the euclidean distance between p and q
-        """
-        return np.sqrt(np.power((float(p[0])-float(q[0])),2)+np.power((float(p[1])-float(q[1])),2))
+        for values, relation in zip(self.all_possible_values[start_idx:end_idx], self.all_possible_relations[start_idx:end_idx]):
+            prob = uniform(0.0, self._normpdf(d, mu=values[0], sigma=values[1]))
+            r = (relation, prob) if prob > r[1] else r
+        self.prev_dist = r[0] if r[0] else self.all_possible_relations[-1]
+        return self.prev_dist

--- a/qsr_lib/src/qsrlib_qsrs/qsr_qtc_simplified_abstractclass.py
+++ b/qsr_lib/src/qsrlib_qsrs/qsr_qtc_simplified_abstractclass.py
@@ -35,7 +35,7 @@ class QSR_QTC_Simplified_Abstractclass(QSR_Dyadic_Abstractclass):
         self._unique_id = ""
         self.qtc_type = ""
 
-        self.__qsr_params_defaults= {
+        self._qsr_params_defaults = {
             "quantisation_factor": 0.0,
             "validate": True,
             "no_collapse": False,
@@ -342,7 +342,7 @@ class QSR_QTC_Simplified_Abstractclass(QSR_Dyadic_Abstractclass):
         return 0, ""
 
     def _process_qsr_parameters_from_request_parameters(self, req_params, **kwargs):
-        qsr_params = self.__qsr_params_defaults.copy()
+        qsr_params = self._qsr_params_defaults.copy()
 
         try: # global namespace
             if req_params["dynamic_args"]["for_all_qsrs"]:
@@ -369,7 +369,7 @@ class QSR_QTC_Simplified_Abstractclass(QSR_Dyadic_Abstractclass):
             raise TypeError("'no_collapse' and 'validate' have to be boolean values.")
 
         for param in qsr_params:
-            if param not in self.__qsr_params_defaults and param not in self._allowed_parameters:
+            if param not in self._qsr_params_defaults and param not in self._allowed_parameters:
                 raise KeyError("%s is an unknown parameter" % str(param))
 
         return qsr_params


### PR DESCRIPTION
Works like qtcbcs but using the abstract probabilities of argprobd. Also had to make a few variables and functions protected instead of private.

See #125 for more detailed explanation.